### PR TITLE
Fix `ddev describe` animation clipping

### DIFF
--- a/src/components/AnimatedTerminal.astro
+++ b/src/components/AnimatedTerminal.astro
@@ -49,7 +49,7 @@ Container ddev-router  Running
     {
       clumps: [
         { transition: "type", lines: 1, wait: 250 },
-        { transition: "show", lines: 27 },
+        { transition: "show", lines: 28 },
       ],
       output: `ddev describe
 ┌─────────────────────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## The Issue

I didn’t realize it, but [this commit](https://github.com/ddev/ddev.com/commit/c3fbd9f1ca6c2d355f9020f36854f45b039c1edc) added lines to the animated `ddev describe` screen, and the bottom of the CLI table is clipped.

## How This PR Solves The Issue

This adjusts the animation settings to account for the extra line.

![Screen Shot 2023-08-28 at 04 41 09 PM@2x](https://github.com/ddev/ddev.com/assets/2488775/8257efc3-1af6-4a00-a1d8-2bd47b0a1791)
