### PR TITLE
Help Feedly find feed links

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -22,8 +22,8 @@ const jsonUrl = new URL(`/blog/feed.json`, Astro.site).toString()
   title={title}
   description={BLOG_DESCRIPTION}
   link={[
-    { rel: "alternate", href: rssUrl },
-    { rel: "alternate", href: jsonUrl },
+    { rel: "alternate", href: rssUrl, type: "application/rss+xml" },
+    { rel: "alternate", href: jsonUrl, type: "application/json" },
   ]}
 >
   <main class="max-w-4xl mx-auto">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,9 +9,19 @@ import Layout from "../layouts/Layout.astro"
 import RepoCard from "@components/RepoCard.astro"
 import SoftwareLogos from "@components/SoftwareLogos.astro"
 import { GITHUB_REPO } from "../const"
+
+const rssUrl = new URL(`/blog/rss.xml`, Astro.site).toString()
+const jsonUrl = new URL(`/blog/feed.json`, Astro.site).toString()
 ---
 
-<Layout title={``} description={`Local development environments in seconds. Customize, share, and extend with ease.`}>
+<Layout
+  title={``}
+  description={`Local development environments in seconds. Customize, share, and extend with ease.`}
+  link={[
+    { rel: "alternate", href: rssUrl },
+    { rel: "alternate", href: jsonUrl },
+  ]}
+>
   <main>
     <Hero />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,8 +18,8 @@ const jsonUrl = new URL(`/blog/feed.json`, Astro.site).toString()
   title={``}
   description={`Local development environments in seconds. Customize, share, and extend with ease.`}
   link={[
-    { rel: "alternate", href: rssUrl },
-    { rel: "alternate", href: jsonUrl },
+    { rel: "alternate", href: rssUrl, type: "application/rss+xml" },
+    { rel: "alternate", href: jsonUrl, type: "application/json" },
   ]}
 >
   <main>
@@ -54,5 +54,6 @@ const jsonUrl = new URL(`/blog/feed.json`, Astro.site).toString()
         </div>
       </div>
     </div>
+    <p>Subscribe to our <a href={rssUrl}>RSS feed</a>.</p>
   </main>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,6 +54,5 @@ const jsonUrl = new URL(`/blog/feed.json`, Astro.site).toString()
         </div>
       </div>
     </div>
-    <p>Subscribe to our <a href={rssUrl}>RSS feed</a>.</p>
   </main>
 </Layout>


### PR DESCRIPTION
## The Issue

If a person plops `https://ddev.com` or `https://ddev.com/blog/` into Feedly, no feeds are listed even though the alternate RSS and JSON feeds are present in `link` tags for blog listing and detail pages.

This is, of course, a bummer.

## How This PR Solves The Issue

This adds those `link` tags to the homepage—which doesn‘t affect it visually—and further specifies a MIME type in each tag’s `type` property. For whatever reason, this makes Feedly happy and it lists “DDEV Blog” twice (once per feed, presumably) if you supply either URL above.

## Manual Testing Instructions

Swing by your Feedly account and add `ddev.com` to the search bar under **Follow your favorite websites**. Joyfully confirm that you’re able to select “DDEV Blog”.

## Automated Testing Overview

n/a

## Related Issue Link(s)

n/a

## Release/Deployment Notes

n/a

