### PR TITLE
Add mobile first spacing to hero header.

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -9,7 +9,7 @@ import AnimatedTerminal from "./AnimatedTerminal.astro"
 import { CloudIcon } from "@heroicons/react/24/solid/index.js"
 ---
 
-<div class="mt-12 pt-24 pb-32 relative overflow-x-hidden">
+<div class="mt-2 pt-8 sm:mt-12 sm:pt-24 pb-32 relative overflow-x-hidden">
   <div class="z-10 max-w-4xl mx-auto relative">
     <div class="max-w-2xl px-6 lg:px-0">
       <h1 class="text-5xl font-bold dark:text-white">


### PR DESCRIPTION
## The Issue

Closes #103 

## How This PR Solves The Issue

It adds smaller margins and paddings on mobile devices.