### PR TITLE
Fix footer contrast on darkmode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,7 @@ footer {
   footer {
     ul a[target="_blank"] {
       &::after {
+        opacity: 1;
         filter: invert(42%) sepia(93%) saturate(1352%) hue-rotate(87deg)
           brightness(119%) contrast(119%);
       }


### PR DESCRIPTION
## The Issue

The icons on the footer match the ones on the brand bar.

<img width="1052" alt="Screen Shot 2023-10-03 at 9 52 53 PM" src="https://github.com/ddev/ddev.com/assets/39039024/7c7ea7d5-c50a-4134-8818-4f07933a6a58">


## How This PR Solves The Issue

<img width="1013" alt="Screen Shot 2023-10-03 at 9 50 17 PM" src="https://github.com/ddev/ddev.com/assets/39039024/1ff32369-82db-4f68-9d3f-0f10d9cce2d3">


