### PR TITLE
Add a blog edit link

### DIFF
--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -17,9 +17,11 @@ export interface Props {
   authorAvatar?: string
   // Human-formatted read time (used for blog posts)
   readTime?: string
+  // Human-formatted read time (used for blog posts)
+  editUrl?: string
 }
 
-const { title, subtitle, date, author, authorUrl, authorAvatar, readTime } =
+const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUrl } =
   Astro.props
 ---
 
@@ -64,10 +66,37 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime } =
         readTime && (
           <span>
             {" "}
-            <span aria-hidden="true"> ·</span> {readTime}
+            <span aria-hidden="true"> · </span> {readTime}
           </span>
         )
       }
     </p>
+    {
+      editUrl && (
+        <span class="dark:text-white">
+            <span aria-hidden="true"> · </span>
+          </span>
+        <a class="flex dark:text-white pl-2" href={editUrl} target="_blank">
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          data-prefix="fas"
+          data-icon="pen"
+          class="svg-inline--fa fa-pen fa-w-16"
+          role="img"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+          height="1em"
+          width="1em"
+        >
+          <path
+            fill="currentColor"
+            d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+          ></path>
+        </svg>
+        <span class="pl-2">Edit this page</span>
+      </a>
+      )
+    }
   </div>
 </div>

--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -44,7 +44,7 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUr
           )}
           {author && (
             <div class={authorAvatar ? `ml-1 dark:text-white` : ``}>
-              <a class="dark:text-white" href={authorUrl}>{author}</a>
+              <a class="dark:text-white hover:underline" href={authorUrl}>{author}</a>
             </div>
           )}
         </div>

--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -73,7 +73,7 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUr
     </p>
     {
       editUrl && (
-        <a class="flex dark:text-white pl-1 sm:pl-4 items-center sm:ml-auto font-serif hover:underline" href={editUrl} target="_blank">
+        <a class="flex dark:text-white pl-1 sm:pl-4 items-center sm:ml-auto font-sans hover:underline" href={editUrl} target="_blank">
         <svg
           aria-hidden="true"
           focusable="false"

--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -73,10 +73,7 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUr
     </p>
     {
       editUrl && (
-        <span class="dark:text-white">
-            <span aria-hidden="true"> · </span>
-          </span>
-        <a class="flex dark:text-white pl-2" href={editUrl} target="_blank">
+        <a class="flex dark:text-white pl-1 sm:pl-4" href={editUrl} target="_blank">
         <svg
           aria-hidden="true"
           focusable="false"

--- a/src/components/Heading.astro
+++ b/src/components/Heading.astro
@@ -73,7 +73,7 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUr
     </p>
     {
       editUrl && (
-        <a class="flex dark:text-white pl-1 sm:pl-4" href={editUrl} target="_blank">
+        <a class="flex dark:text-white pl-1 sm:pl-4 items-center sm:ml-auto font-serif hover:underline" href={editUrl} target="_blank">
         <svg
           aria-hidden="true"
           focusable="false"
@@ -83,8 +83,8 @@ const { title, subtitle, date, author, authorUrl, authorAvatar, readTime, editUr
           role="img"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 512 512"
-          height="1em"
-          width="1em"
+          height="0.8em"
+          width="0.8em"
         >
           <path
             fill="currentColor"

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,6 +2,7 @@ export const SITE_TITLE = 'DDEV';
 export const SITE_DESCRIPTION = 'Docker-based local PHP development environments.';
 export const GITHUB_REPO = 'ddev/ddev';
 export const GITHUB_URL = 'https://github.com/ddev/ddev';
+export const GITHUB_URL_WEBSITE = 'https://github.com/ddev/ddev.com/tree/main/src/content/blog';
 export const GITHUB_ISSUES_URL = 'https://github.com/ddev/ddev/issues';
 export const DOCUMENTATION_URL = 'https://ddev.readthedocs.io/';
 export const DISCORD_URL = 'https://discord.gg/hCZFfAMc5k';

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -7,7 +7,7 @@ import Heading from "./../../components/Heading.astro"
 import BlogPostFooter from "./../../components/BlogPostFooter.astro"
 import FeatureImage from "./../../components/FeatureImage.astro"
 import PostUpdate from "./../../components/PostUpdate.astro"
-import { BLOG_DESCRIPTION } from "src/const"
+import { BLOG_DESCRIPTION, GITHUB_URL_WEBSITE } from "src/const"
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection("blog")
@@ -86,6 +86,7 @@ const blogPostSchema = [
       authorUrl={`/blog/author/${author.slug}`}
       authorAvatar={authorImage}
       readTime={remarkPluginFrontmatter.minutesRead}
+      editUrl={GITHUB_URL_WEBSITE+`/`+entry.slug+`.md`}
     />
     {
       hasFeatureImage && shouldDisplayFeatureImage && (


### PR DESCRIPTION
## The Issue
The docs have a quick edit button that directs one straight to the docs but the blog does not.
This PR tries to address that.

## How This PR Solves The Issue

<img width="1053" alt="Screen Shot 2023-10-04 at 7 34 59 PM" src="https://github.com/ddev/ddev.com/assets/39039024/1c78a92c-5a2d-44e6-8a2a-9b74c5eeba9f">

I used the example the Astro docs had and placed it on what seemed to be the most convenient place.
