### PR TITLE
Fixes dark mode contrast issue with html mark.

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -62,3 +62,8 @@ img {
     @apply absolute top-0 left-0 w-full h-full;
   }
 }
+
+/* DarkMode for mark*/
+mark {
+  @apply dark:bg-[blue]
+}


### PR DESCRIPTION
## The Issue
<img width="868" alt="Screenshot 2024-01-29 at 8 33 27 PM" src="https://github.com/ddev/ddev.com/assets/39039024/b84dda8f-4c0c-4b72-9382-5d38a21e7512">
https://ddev.com/blog/drupal7-drupal9-migration-ddev-acquia-migrate-accelerate/

## How This PR Solves The Issue

With dark mode, the text highlighted in yellow becomes too hard to read.
This switches it to HTML blue.