### PR TITLE
Allow the word just

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -34,7 +34,6 @@
     "stop-words": {
       "defaultWords": false,
       "words": [
-        ["just"],
         ["simply"]
       ],
     }


### PR DESCRIPTION
## The Issue

While well-intentioned, the ban on the word "just" causes unjust and unnecessary reformulations of sentences. It's doing more harm than good. I'll try not to use the word in a demeaning way.

