### PR TITLE
switch default to Orbstack for get started

### DIFF
--- a/src/components/quickstart/Mac.astro
+++ b/src/components/quickstart/Mac.astro
@@ -12,7 +12,7 @@ const { latestVersion } = Astro.props
 
 <div class="prose dark:prose-invert">
   <p class="text-gray-600 mb-16 dark:text-slate-400">
-    We’ll use Docker Desktop since it’s the most straightforward of <a
+    We’ll use Orbstack since it’s the most straightforward of <a
       href="https://ddev.readthedocs.io/en/stable/users/install/docker-installation/#macos"
       >several options</a
     >.
@@ -29,17 +29,17 @@ const { latestVersion } = Astro.props
     <div class="prose py-5 dark:prose-invert">
       <p>
         With <a href="https://brew.sh" target="_blank">Homebrew</a> installed, you
-        can install Docker Desktop with one command:
+        can install Orbstack with one command:
       </p>
-      <Terminal code={`→ brew install --cask docker`} />
+      <Terminal code={`→ brew install orbstack docker`} />
     </div>
   </Fragment>
   <Fragment slot="Download">
     <div class="prose py-5 dark:prose-invert">
       <p>
         Download and run the <a
-          href="https://www.docker.com/products/docker-desktop"
-          target="_blank">Docker Desktop installer</a
+          href="https://orbstack.dev/download"
+          target="_blank">Orbstack installer</a
         >.
       </p>
     </div>
@@ -48,12 +48,11 @@ const { latestVersion } = Astro.props
 
 <div class="prose dark:prose-invert">
   <p>
-    Launch Docker Desktop, accept the license agreement, and make sure Docker is
-    started and running.
+    Launch Orbstack, accept the license agreement.
   </p>
 
-  <p>Confirm that you’ve now got a Docker provider:</p>
-  <Terminal code={`→ docker -v\nDocker version 24.0.5, build ced0996`} />
+  <p>Confirm that you now have a Docker provider:</p>
+  <Terminal code={`→ docker version`} />
 
   <h2 class="text-3xl mt-24">
     <small class="block font-mono text-xs text-gray-500">2/3</small>Install DDEV

--- a/src/components/quickstart/Mac.astro
+++ b/src/components/quickstart/Mac.astro
@@ -19,8 +19,7 @@ const { latestVersion } = Astro.props
   </p>
 
   <h2 class="text-3xl mt-24">
-    <small class="block font-mono text-xs text-gray-500">1/3</small>Install
-    Docker
+    <small class="block font-mono text-xs text-gray-500">1/3</small>Install Orbstack Docker Provider
   </h2>
 </div>
 


### PR DESCRIPTION
## The Issue

Our default/easiest recommendation these days is Orbstack, not Docker Desktop

Switch to the new recommendation

Review at https://20240328-use-orbstack.ddev-com-front-end.pages.dev/get-started/ - macOS version

