### PR TITLE
fix: make tests work again, bump GitHub dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run textlint
+      # Remove this when https://github.com/withastro/action/pull/52 is merged
       - name: Remove yarn.lock because it breaks withastro/action@v2
         run: find node_modules -name "yarn.lock" -exec rm -f {} +
       - name: Install, build, and upload your site output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run textlint
+      - name: Remove yarn.lock because it breaks withastro/action@v2
+        run: find node_modules -name "yarn.lock" -exec rm -f {} +
       - name: Install, build, and upload your site output
         uses: withastro/action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,17 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_VERSION: 20
 
 jobs:
   build:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
         run: npm ci
       - name: Lint
@@ -30,3 +31,5 @@ jobs:
         run: find node_modules -name "yarn.lock" -exec rm -f {} +
       - name: Install, build, and upload your site output
         uses: withastro/action@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## The Issue

Tests are broken:

```
Warning: No existing directories found containing cache-dependency-path="./yarn.lock"
```

I investigated this and found that it is a problem in `withastro/action@v2`

I opened a PR there, but don't know if it is going to be merged soon:

- https://github.com/withastro/action/pull/52

## How This PR Solves The Issue

1. Removes all `yarn.lock` files from `node_modules` directory before running `withastro/action@v2`. (This workaround can be removed later.)
2. Bumps `actions/checkout` and `actions/setup-node` to `v4`.
3. I found out that `withastro/action@v2` uses `node-version`, but we do not set it explicitly - fixed.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

