### PR TITLE
Use `M Series` as a badge for macOS

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -39,7 +39,7 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><Icon name="Apple" />
           </span>
-          macOS <Badge>M1</Badge><Badge>M2</Badge><Badge>Intel</Badge>
+          macOS <Badge>M Series</Badge><Badge>Intel</Badge>
         </li>
         <li class="whitespace-nowrap my-1">
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"


### PR DESCRIPTION
## The Issue

The macOS badge on the main page mentions M1, M2, but M3 is already there and M4 is almost out.

![image](https://github.com/ddev/ddev.com/assets/24270994/0189f558-5737-43d0-a08a-3b5f7c83b2b0)

## How This PR Solves The Issue

Use `M Series` as the generic name, I got it from https://en.wikipedia.org/wiki/Apple_silicon

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

