### PR TITLE
Remove extra slash in the search URL results

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -43,7 +43,7 @@ const title = `Search`
 
     resultsContainer.innerHTML = results
       .map((result) => {
-        let resulturl = window.location.origin + result.id
+        let resulturl = window.location.origin + result.id.replace(/^\/+/, '/');
         return `
         <a href="${
           resulturl


### PR DESCRIPTION
## The Issue

When you search something here https://ddev.com/search/, it produces a link with double slash

![image](https://github.com/user-attachments/assets/b256ff71-c21b-44f1-aca6-199f0d2e3dda)

## How This PR Solves The Issue

Removes this extra slash.

## Manual Testing Instructions

Try searching here https://20240714-stasadev-search-ext.ddev-com-front-end.pages.dev/search/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

