### PR TITLE
Wrap iframe video links for mobile

### DIFF
--- a/src/content/blog/ddev-docker-architecture.md
+++ b/src/content/blog/ddev-docker-architecture.md
@@ -15,7 +15,9 @@ categories:
 
 At the simplest conceptual level, DDEV is a wrapper on Docker and `docker-compose`. Here's our [Contributor Training](contributor-training.md) explaining how we use Docker in DDEV, including the Docker images and containers and how they're related.
 
+<div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ee1YFvATQKw?si=2Fovta2MheJJdG-T" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 ## What is a Docker Image? What is a Docker Container?
 

--- a/src/content/blog/golang-debugging.md
+++ b/src/content/blog/golang-debugging.md
@@ -16,7 +16,9 @@ categories:
 
 It's not hard to work with DDEV's Golang code, but you definitely need a development environment and the know-how to do step-debugging. Here's our [Contributor Training](contributor-training.md) showing some of the nuances with DDEV, followed by a short summary of the details.
 
+<div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/E-AEzC1p76E?si=XYP23HYcxgqiJ2_M" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 First, you need some of the basics:
 

--- a/src/content/blog/one-minute-wordpress.md
+++ b/src/content/blog/one-minute-wordpress.md
@@ -39,7 +39,7 @@ Creating a quick, destructible WordPress site can be handy for testing new theme
 
 You should hit the WordPress installer screen and then you’re off to the races! To get access to the database credentials to complete the installation, run `ddev describe`.
 
-<div class="video-wrapper">
+<div class="video-container">
 <iframe src="https://www.youtube.com/embed/b-6EX3KCbnY" width="560" height="315" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
 </div>
 
@@ -47,7 +47,7 @@ You should hit the WordPress installer screen and then you’re off to the races
 
 Once you’re able to get up and running, you can begin to explore the [additional functionality](https://github.com/ddev/ddev#usage) including imports, local development tools, managing multiple containers, etc. Below is a quick video tour.
 
-<div class="video-wrapper">
+<div class="video-container">
 <iframe loading="lazy" src="https://www.youtube.com/embed/JQrjsazBzP4" width="560" height="315" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
 </div>
 

--- a/src/content/blog/randy-in-patagonia.md
+++ b/src/content/blog/randy-in-patagonia.md
@@ -12,7 +12,10 @@ categories:
 ---
 
 TL;DR: Watch Randy's slideshow about this trip:
+
+<div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/5zPWGRfNW-k?si=uk_ejG-2kqA8rt28" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
 
 Some of you know that my wife Nancy and I have done lots of pretty ambitious bike touring over the last 20 years or so. From 2006-2009, [we rode 14,000 miles
 ](https://hobobiker.com)(22,000 km) through the Americas from near the Arctic Ocean in Canada to Puerto Montt in Patagonian Chile, South America.  

--- a/src/content/blog/traefik-configuration-contributor-training.md
+++ b/src/content/blog/traefik-configuration-contributor-training.md
@@ -16,7 +16,9 @@ DDEV's **router** is the system component that accepts HTTP and HTTPS requests a
 
 Here's our June 19, 2024 [Contributor Training](/blog/category/training) on how the Traefik router works in DDEV:
 
+<div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/9f9Zbze7VP8?si=D9hywble6WqdqVa5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 ## What is Traefik and the `ddev-router`?
 

--- a/src/content/blog/xdebug-debugging.md
+++ b/src/content/blog/xdebug-debugging.md
@@ -18,7 +18,9 @@ PHP developers have long had a variety of complications using Xdebug. It's a net
 
 Here's a recording of our [Xdebug contributor Training](https://www.meetup.com/ddev-events/events/301101460/) walking through DDEV and Xdebug. Please sign up on the [meetup](https://www.meetup.com/ddev-events/) so you'll get notified of future trainings.
 
+<div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/4MrwXTaHfnc?si=nwocfW8FjXitbtSa" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 First of all, congratulations for making step-debugging a priority. It's my opinion that step-debugging is one of the very first things to learn in any language or environment that we undertake. 
 


### PR DESCRIPTION
## The Issue

Some iframe video links look bad on mobile https://ddev.com/blog/xdebug-debugging/

![image](https://github.com/user-attachments/assets/e8946012-8176-4f79-982d-1dc5c6a1c55d)

## How This PR Solves The Issue

Wraps them into `<div class="video-container"></div>`

## Manual Testing Instructions

Open on mobile (or change the view to mobile using the browser's developer console)
https://20240714-stasadev-wrap-ifram.ddev-com-front-end.pages.dev/blog/xdebug-debugging

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

