### PR TITLE
Remove expired sponsors from sponsors list

### DIFF
--- a/src/featured-sponsors.json
+++ b/src/featured-sponsors.json
@@ -34,24 +34,6 @@
     "github": "open-strategy-partners"
   },
   {
-    "name": "1xINTERNET",
-    "type": "standard",
-    "logo": "/logos/1xinternet.svg",
-    "darklogo": "/logos/1xinternet.svg",
-    "squareLogo": "/logos/1xinternet-square.svg",
-    "url": "https://1xinternet.de",
-    "github": "1xINTERNET"
-  },
-  {
-    "name": "Amazee.io",
-    "type": "standard",
-    "logo": "/logos/amazee-io-Mirantis-Logo-Black-White-IO.svg",
-    "darklogo": "/logos/amazee-io-mirantis-darkmode.svg",
-    "squareLogo": "/logos/amazee-io-square.svg",
-    "url": "https://amazee.io/",
-    "github": "amazee.io"
-  },
-  {
     "name": "Agaric",
     "type": "standard",
     "logo": "/logos/agaric.svg",
@@ -104,15 +86,6 @@
     "squareLogo": "/logos/gizra.svg",
     "url": "https://gizra.com/",
     "github": "gizra"
-  },
-  {
-    "name": "DrupalEasy",
-    "type": "standard",
-    "logo": "/logos/drupaleasy.png",
-    "darklogo": "/logos/drupaleasy-darkmode.png",
-    "squareLogo": "/logos/drupaleasy-square.svg",
-    "url": "https://www.drupaleasy.com/",
-    "github": "drupaleasy"
   },
   {
     "name": "mobilistics",
@@ -175,14 +148,5 @@
     "squareLogo": "/logos/craft-cms-square.svg",
     "url": "https://craftcms.com/",
     "github": "craftcms"
-  },
-  {
-    "name": "undpaul",
-    "type": "standard",
-    "logo": "/logos/undpaul.svg",
-    "darklogo": "/logos/undpaul-darkmode.svg",
-    "squareLogo": "/logos/undpaul-square.svg",
-    "url": "https://undpaul.de",
-    "github": "undpaul"
   }
 ]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,64 +85,43 @@ export async function getSponsors() {
   }
 
   const response = await octokit().graphql(`
-  query {
-    user(login: "rfay") {
-      ... on Sponsorable {
+    query CombinedSponsors {
+      org: organization(login: "ddev") {
         sponsors(first: 100) {
-          totalCount
           nodes {
             ... on User {
               login
               url
               avatarUrl
-              sponsorshipForViewerIsActive
             }
             ... on Organization {
               login
               url
               avatarUrl
-              sponsorshipForViewerIsActive
             }
           }
         }
       }
-    }
-    organization(login: "ddev") {
-      ... on Sponsorable {
+      user: user(login: "rfay") {
         sponsors(first: 100) {
-          totalCount
           nodes {
             ... on User {
               login
               url
               avatarUrl
-              sponsorshipForViewerIsActive
             }
             ... on Organization {
               login
               url
               avatarUrl
-              sponsorshipForViewerIsActive
             }
           }
         }
       }
     }
-  }
-`);
+  `)
 
-// Filter for active sponsors
-  const activeSponsors = {
-    rfay: response.user.sponsors.nodes.filter(sponsor => sponsor.sponsorshipForViewerIsActive),
-    ddev: response.organization.sponsors.nodes.filter(sponsor => sponsor.sponsorshipForViewerIsActive),
-  };
-
-  const rfayData = activeSponsors.rfay.nodes
-  const orgData = activeSponsors.ddev.nodes
-  const data = [...rfayData, ...orgData]
-  
-  console.log("rfayData", rfayData)
-  console.log("orgData", orgData)
+  const data = response
 
   putCache(cacheFilename, JSON.stringify(data))
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -121,11 +121,21 @@ export async function getSponsors() {
     }
   `)
 
-  const data = response
+  // Combine sponsors from both sources and remove duplicates
+  const allSponsors = [
+    ...response.org.sponsors.nodes,
+    ...response.user.sponsors.nodes
+  ].reduce((unique, sponsor) => {
+    // Use login as unique identifier
+    if (!unique.some(item => item.login === sponsor.login)) {
+      unique.push(sponsor)
+    }
+    return unique
+  }, [])
 
-  putCache(cacheFilename, JSON.stringify(data))
+  putCache(cacheFilename, JSON.stringify(allSponsors))
 
-  return data
+  return allSponsors
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -88,7 +88,7 @@ export async function getSponsors() {
     query {
       user(login: "rfay") {
         ... on Sponsorable {
-          sponsors(first: 100) {
+          sponsors(first: 100, isActive: true) {
             totalCount
             nodes {
               ... on User {
@@ -107,7 +107,7 @@ export async function getSponsors() {
       }
       organization(login: "ddev") {
         ... on Sponsorable {
-          sponsors(first: 100) {
+          sponsors(first: 100, isActive: true) {
             totalCount
             nodes {
               ... on User {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,51 +85,64 @@ export async function getSponsors() {
   }
 
   const response = await octokit().graphql(`
-    query {
-      user(login: "rfay") {
-        ... on Sponsorable {
-          sponsors(first: 100, isActive: true) {
-            totalCount
-            nodes {
-              ... on User {
-                login
-                url
-                avatarUrl
-              }
-              ... on Organization {
-                login
-                url
-                avatarUrl
-              }
+  query {
+    user(login: "rfay") {
+      ... on Sponsorable {
+        sponsors(first: 100) {
+          totalCount
+          nodes {
+            ... on User {
+              login
+              url
+              avatarUrl
+              sponsorshipForViewerIsActive
             }
-          }
-        }
-      }
-      organization(login: "ddev") {
-        ... on Sponsorable {
-          sponsors(first: 100, isActive: true) {
-            totalCount
-            nodes {
-              ... on User {
-                login
-                url
-                avatarUrl
-              }
-              ... on Organization {
-                login
-                url
-                avatarUrl
-              }
+            ... on Organization {
+              login
+              url
+              avatarUrl
+              sponsorshipForViewerIsActive
             }
           }
         }
       }
     }
-  `)
+    organization(login: "ddev") {
+      ... on Sponsorable {
+        sponsors(first: 100) {
+          totalCount
+          nodes {
+            ... on User {
+              login
+              url
+              avatarUrl
+              sponsorshipForViewerIsActive
+            }
+            ... on Organization {
+              login
+              url
+              avatarUrl
+              sponsorshipForViewerIsActive
+            }
+          }
+        }
+      }
+    }
+  }
+`);
 
-  const rfayData = response.user.sponsors.nodes
-  const orgData = response.organization.sponsors.nodes
+// Filter for active sponsors
+  const activeSponsors = {
+    rfay: response.user.sponsors.nodes.filter(sponsor => sponsor.sponsorshipForViewerIsActive),
+    ddev: response.organization.sponsors.nodes.filter(sponsor => sponsor.sponsorshipForViewerIsActive),
+  };
+
+  const rfayData = activeSponsors.rfay.nodes
+  const orgData = activeSponsors.ddev.nodes
   const data = [...rfayData, ...orgData]
+  
+  console.log("rfayData", rfayData)
+  console.log("orgData", orgData)
 
   putCache(cacheFilename, JSON.stringify(data))
 


### PR DESCRIPTION
## The Issue

We've been showing long-since expired github sponsors and featured sponsors, and that's not fair to the folks that are currently active.

## How This PR Solves The Issue

* Remove inactive featured sponsors
* Remove inactive github sponsors

## Manual Testing Instructions

Review the results on the rendered home page

Rendered 
* [main page](https://20241108-remove-not-current.ddev-com-front-end.pages.dev/#supporters)
* [support ddev page](https://20241108-remove-not-current.ddev-com-front-end.pages.dev/support-ddev/#sponsor-development)

It won't show up on https://github.com/ddev/ddev yet of course, but that should be the same.

