### PR TITLE
docs: Fix `ssh` test command

### DIFF
--- a/src/content/blog/windows-ddev-setup.md
+++ b/src/content/blog/windows-ddev-setup.md
@@ -40,7 +40,7 @@ Two recent Windows machines I set up were the new ARM64/Qualcomm/CoPilot variety
     * On ARM64, `choco uninstall -y mkcert gsudo` so that the DDEV installer can get the native versions of each of these.
     * On ARM64, install the Windows-side DDEV from the installer in the [DDEV releases](https://github.com/ddev/ddev/releases). We'll probably discontinue documenting the Chocolatey install technique in the future.)
 11. Install and test the fantastic [1Password ssh agent](https://developer.1password.com/docs/ssh/agent/).
-12. On Windows PowerShell `ssh git@github.com git@github.com` to verify that the 1Password SSH agent is working. If it says "PTY Allocation Failed", just hit `<RETURN>` and ignore it. You should get the confirmation message from GitHub.
+12. On Windows PowerShell `ssh git@github.com` to verify that the 1Password SSH agent is working. If it says "PTY Allocation Failed", just hit `<RETURN>` and ignore it. You should get the confirmation message from GitHub.
 13. 1Password WSL2 adaptation:
     `sudo ln -s /mnt/c/WINDOWS/System32/OpenSSH/ssh.exe /usr/local/bin/ssh && sudo ln -s /mnt/c/WINDOWS/System32/OpenSSH/ssh-add.exe /usr/local/bin/ssh-add` (Makes ssh use `ssh.exe` on Windows and the 1Password SSH and Git integrations then work great. This assumes that `/usr/local/bin` in your PATH comes before `/usr/bin`)
 14. If you have a `dotfiles` repository (containing your shared `.bash_profile`, `.zshrc`, etc.) clone it in WSL2.

--- a/src/content/blog/windows-ddev-setup.md
+++ b/src/content/blog/windows-ddev-setup.md
@@ -40,7 +40,7 @@ Two recent Windows machines I set up were the new ARM64/Qualcomm/CoPilot variety
     * On ARM64, `choco uninstall -y mkcert gsudo` so that the DDEV installer can get the native versions of each of these.
     * On ARM64, install the Windows-side DDEV from the installer in the [DDEV releases](https://github.com/ddev/ddev/releases). We'll probably discontinue documenting the Chocolatey install technique in the future.)
 11. Install and test the fantastic [1Password ssh agent](https://developer.1password.com/docs/ssh/agent/).
-12. On Windows PowerShell `ssh git@github.com` to verify that the 1Password SSH agent is working. If it says "PTY Allocation Failed", just hit `<RETURN>` and ignore it. You should get the confirmation message from GitHub.
+12. On Windows PowerShell `ssh -T git@github.com` to verify that the 1Password SSH agent is working. If it says "PTY Allocation Failed", just hit `<RETURN>` and ignore it. You should get the confirmation message from GitHub.
 13. 1Password WSL2 adaptation:
     `sudo ln -s /mnt/c/WINDOWS/System32/OpenSSH/ssh.exe /usr/local/bin/ssh && sudo ln -s /mnt/c/WINDOWS/System32/OpenSSH/ssh-add.exe /usr/local/bin/ssh-add` (Makes ssh use `ssh.exe` on Windows and the 1Password SSH and Git integrations then work great. This assumes that `/usr/local/bin` in your PATH comes before `/usr/bin`)
 14. If you have a `dotfiles` repository (containing your shared `.bash_profile`, `.zshrc`, etc.) clone it in WSL2.


### PR DESCRIPTION
## The Issue

The current command generates an error:

```shell
❯ ssh git@github.com git@github.com
Invalid command: git@github.com
You appear to be using ssh to clone a git:// URL.
```

Confirmed issues in the following terminals:

- PowerShell 7.4.6
- Windows Powershell 5.1.22621.4391
- Git bash 2.47.0.windows.2

## How This PR Solves The Issue

Update the command.
Now generates the following:

```
❯  ssh git@github.com
Enter passphrase for key '/c/Users/XXXXXX/.ssh/id_ed25519':
Hi XXXXXX! You've successfully authenticated, but GitHub does not provide shell access.
```

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

