### PR TITLE
Add note stating OrbStack is not free for professional use, fixes #286

### DIFF
--- a/src/components/quickstart/Mac.astro
+++ b/src/components/quickstart/Mac.astro
@@ -17,7 +17,7 @@ const { latestVersion } = Astro.props
       href="https://ddev.readthedocs.io/en/stable/users/install/docker-installation/#macos"
       target="_blank"
       >several options</a
-    >.
+    >. Please note that OrbStack is not free for professional use.
   </p>
 
   <h2 class="text-3xl mt-24">

--- a/src/components/quickstart/Mac.astro
+++ b/src/components/quickstart/Mac.astro
@@ -13,11 +13,11 @@ const { latestVersion } = Astro.props
 
 <div class="prose dark:prose-invert">
   <p class="text-gray-600 mb-16 dark:text-slate-400">
-    We’ll use OrbStack since it’s the most straightforward of <a
+    We’ll use OrbStack since it’s the simplest of <a
       href="https://ddev.readthedocs.io/en/stable/users/install/docker-installation/#macos"
       target="_blank"
       >several options</a
-    >. Please note that OrbStack is not free for professional use.
+    >. OrbStack is not free for professional use, but several other options are open-source and free to use.
   </p>
 
   <h2 class="text-3xl mt-24">
@@ -77,7 +77,7 @@ const { latestVersion } = Astro.props
 
 
 <div class="prose dark:prose-invert">
-  <p>Confirm that you’ve now got DDEV installed: 🎉</p>
+  <p>Confirm that DDEV is installed: 🎉</p>
   <Terminal code={`→ ddev -v\nddev version ${latestVersion}`} />
 
   <h2 class="text-3xl mt-24">


### PR DESCRIPTION
## The Issue

* #286 

The [Get Started](https://ddev.com/get-started/) guide uses OrbStack, but does not mention that OrbStack is commercial software.

## How This PR Solves The Issue
Added a one-sentence note stating OrbStack is not free for professional use in the [Get Started](https://ddev.com/get-started/) page.

## Related Issue Link(s)
https://github.com/ddev/ddev.com/issues/286

