### PR TITLE
Fix more slugs after Astro upgrade, fixes #294

### DIFF
--- a/src/components/BlogPostFooter.astro
+++ b/src/components/BlogPostFooter.astro
@@ -14,7 +14,7 @@ const orderedPosts = posts.sort((a, b) => {
 })
 
 orderedPosts.forEach((post, index) => {
-  if (post.slug === activeSlug) {
+  if (post.id === activeSlug) {
     if (posts[index - 1]) {
       prev = posts[index - 1]
     }
@@ -32,7 +32,7 @@ orderedPosts.forEach((post, index) => {
   {
     prev && (
       <a
-        href={`/blog/${prev.slug}`}
+        href={`/blog/${prev.id}`}
         rel="prefetch"
         class="flex border items-center rounded-md w-full my-1 md:my-0 content-center justify-start md:justify-start p-4 hover:border-blue-300 hover:shadow-sm dark:border-slate-700"
         title={`Previous: ${prev.data.title}`}
@@ -49,7 +49,7 @@ orderedPosts.forEach((post, index) => {
   {
     next && (
       <a
-        href={`/blog/${next.slug}`}
+        href={`/blog/${next.id}`}
         rel="prefetch"
         class="flex border items-center rounded-md w-full my-1 md:my-0 content-center justify-start md:justify-end md:text-right p-4 hover:border-blue-300 hover:shadow-sm dark:border-slate-700"
         title={`Next: ${next.data.title}`}

--- a/src/pages/blog/rss.xml.js
+++ b/src/pages/blog/rss.xml.js
@@ -39,7 +39,7 @@ const items = recentPosts.map((post) => {
   postContent += ensureAbsoluteUrls(marked.parse(post.body))
 
   return {
-    link: `${blogUrl}/${post.slug}`,
+    link: `${blogUrl}/${post.id}`,
     title: post.data.title,
     description: post.data.summary,
     categories: post.data.categories,


### PR DESCRIPTION
## The Issue

- #294

Also I noticed that there was no links to previous posts at the bottom of the post:

![image](https://github.com/user-attachments/assets/efafcbba-f69b-413b-a882-1f01a16654bb)

## How This PR Solves The Issue

Astro replaced `slug` with `id` in most places.

## Manual Testing Instructions

See https://20241223-stasadev-rss-astro.ddev-com-front-end.pages.dev/blog/rss.xml

Before

```xml
<title>DDEV December 2024 Newsletter</title>
<link>https://ddev.com/blog/undefined</link>
<guid isPermaLink="true">https://ddev.com/blog/undefined</guid>
<description>DDEV November 2024 Newsletter</description>
<pubDate>Tue, 03 Dec 2024 00:00:00 GMT</pubDate>
```

After

```xml
<title>DDEV December 2024 Newsletter</title>
<link>https://ddev.com/blog/ddev-dec-2024-newsletter</link>
<guid isPermaLink="true">https://ddev.com/blog/ddev-dec-2024-newsletter</guid>
<description>DDEV November 2024 Newsletter</description>
<pubDate>Tue, 03 Dec 2024 00:00:00 GMT</pubDate>
```

---

Bottom navigation is back https://20241223-stasadev-rss-astro.ddev-com-front-end.pages.dev/blog/ddev-dec-2024-newsletter/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

