### PR TITLE
Blog announcing change in Platform.sh sponsorship

### DIFF
--- a/src/content/blog/platform-sh-becomes-a-lead-sponsor-of-ddev.md
+++ b/src/content/blog/platform-sh-becomes-a-lead-sponsor-of-ddev.md
@@ -1,7 +1,7 @@
 ---
 title: "Platform.sh becomes a Lead Sponsor of DDEV!"
 pubDate: 2022-05-27
-modifiedDate: 2025-01-03
+modifiedDate: 2025-01-07
 summary: Announcement of Platform.sh’s commitment to sponsoring DDEV development.
 author: Randy Fay
 featureImage:
@@ -11,7 +11,7 @@ categories:
   - Announcements
 ---
 
-Update 2025-01-03: Platform.sh has [changed its generous support](platform-sh-ddev-funding-changes.md).
+Update 2025-01-07: Platform.sh has [changed its generous support](platform-sh-ddev-funding-changes.md).
 
 Although many of you know this, I wanted to make a formal announcement of some great news. _[Platform.sh](https://platform.sh) has stepped up to become a lead sponsor of the [DDEV open-source project](https://github.com/ddev/ddev)!_
 

--- a/src/content/blog/platform-sh-becomes-a-lead-sponsor-of-ddev.md
+++ b/src/content/blog/platform-sh-becomes-a-lead-sponsor-of-ddev.md
@@ -1,6 +1,7 @@
 ---
 title: "Platform.sh becomes a Lead Sponsor of DDEV!"
 pubDate: 2022-05-27
+modifiedDate: 2025-01-03
 summary: Announcement of Platform.sh’s commitment to sponsoring DDEV development.
 author: Randy Fay
 featureImage:
@@ -9,6 +10,8 @@ featureImage:
 categories:
   - Announcements
 ---
+
+Update 2025-01-03: Platform.sh has [changed its generous support](platform-sh-ddev-funding-changes.md).
 
 Although many of you know this, I wanted to make a formal announcement of some great news. _[Platform.sh](https://platform.sh) has stepped up to become a lead sponsor of the [DDEV open-source project](https://github.com/ddev/ddev)!_
 

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -1,0 +1,39 @@
+---
+title: "Changes in Platform.sh Funding of DDEV"
+pubDate: 2025-01-03
+#modifiedDate: 2024-09-06
+summary: Changes in Platform.sh Funding of DDEV
+author: Randy Fay
+#featureImage:
+#  src: /img/blog/2024/12/nancy_lewis_colorado_river.jpg
+#  alt: Nancy Lewis painting of Colorado River near Palisade, Colorado
+#  credit: Nancy Lewis painting of the Colorado River near Palisade, Colorado
+categories:
+  - Community
+---
+
+As many of you know, [Platform.sh](https://platform.sh) is a key supporter and funder of DDEV. They generously stepped in to and to become the lead sponsor of DDEV and to rescue the "DDEV" trademark and its use [in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md). 
+
+Of course, time moves along and sometimes organizations have to change their priorities, and in 2025 Platform.sh has decided to change its approach, but still remains a generous lead sponsor at the *partner* level. (Your organization can join them!)
+
+* Instead of funding maintainer Randy Fay as an employee, Platform.sh will fund the DDEV Foundation with a generous 3000 Euros/month.
+* Platform.sh will transfer the "DDEV" trademark and control of the `ddev.com` and `ddev.site` domain names to the DDEV Foundation.
+* We'll continue to maintain the [ddev-platformsh](https://github.com/ddev/ddev-platformsh) add-on and explore an [Upsun](https://upsun.com) add-on.
+
+We'll be preparing updated financial plans for 2025 to adjust to this change, and continue to be enormously thankful for the support of Platform.sh!
+
+This change in funding mode will give DDEV more flexibility in use of funds, and is expected to be a solid move to [full support for Stas Zhuk](lets-fund-stas-maintainer.md).
+
+As many of you know, though, times are tight in the agency world, and funding for DDEV has actually declined in the last year, with a couple of key sponsors having to back away. We hope you and your organization are coming up with new plans to support DDEV.
+
+**THANKS to all of you who are supporting DDEV’s path to sustainability** and who have gotten your organizations to do so.
+
+**Stop by and thank Platform.sh** for their generous ongoing support of DDEV! See their [contact page](https://platform.sh/contact/) or join their [discord](https://discord.gg/platformsh).
+
+Want to keep up as the month goes along? Follow on
+
+- [blog](https://ddev.com/blog/)
+- [LinkedIn](https://www.linkedin.com/company/ddev-foundation)
+- [Mastodon](https://fosstodon.org/@ddev)
+- [Bluesky](https://bsky.app/profile/ddev.bsky.social)
+- and join our community on [Discord](/s/discord)

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -1,6 +1,6 @@
 ---
 title: "Changes in Platform.sh Funding of DDEV"
-pubDate: 2025-01-07
+pubDate: 2025-01-06
 #modifiedDate: 2024-09-06
 summary: Changes in Platform.sh Funding of DDEV
 author: Randy Fay

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -1,6 +1,6 @@
 ---
 title: "Changes in Platform.sh Funding of DDEV"
-pubDate: 2025-01-03
+pubDate: 2025-01-07
 #modifiedDate: 2024-09-06
 summary: Changes in Platform.sh Funding of DDEV
 author: Randy Fay
@@ -21,9 +21,9 @@ Of course, time moves along and sometimes organizations have to change their pri
 
 We'll be preparing updated financial plans for 2025 to adjust to this change, and continue to be enormously thankful for the support of Platform.sh!
 
-This change in funding mode will give DDEV more flexibility in use of funds, and is expected to be a solid move to [full support for Stas Zhuk](lets-fund-stas-maintainer.md).
+This change in funding mode will give DDEV more flexibility in use of funds, and is expected to be a solid move toward [full support for Stas Zhuk](lets-fund-stas-maintainer.md).
 
-As many of you know, though, times are tight in the agency world, and funding for DDEV has actually declined in the last year, with a couple of key sponsors having to back away. We hope you and your organization are coming up with new plans to support DDEV.
+As many of you know, though, times are tight in the agency world, and funding for DDEV has actually declined in the last year, with several key sponsors having to back away. We hope you and your organization are coming up with new plans to support DDEV.
 
 **THANKS to all of you who are supporting DDEV’s path to sustainability** and who have gotten your organizations to do so.
 

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -15,7 +15,7 @@ As many of you know, [Platform.sh](https://platform.sh) is a key supporter and f
 
 Of course, time moves along and sometimes organizations have to change their priorities, and in 2025 Platform.sh has decided to change its approach, but still remains a generous lead sponsor at the _partner_ level. (Your organization can join them!)
 
-- Instead of funding maintainer Randy Fay as an employee, Platform.sh will fund the DDEV Foundation with a generous 3000 Euros/month.
+- Instead of funding maintainer Randy Fay as an employee, Platform.sh will fund the DDEV Foundation with a generous €3000/month.
 - Platform.sh will transfer the "DDEV" trademark and control of the `ddev.com` and `ddev.site` domain names to the DDEV Foundation.
 - We'll continue to maintain the [ddev-platformsh](https://github.com/ddev/ddev-platformsh) add-on and explore an [Upsun](https://upsun.com) add-on.
 

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -11,7 +11,7 @@ categories:
   - Community
 ---
 
-As many of you know, [Platform.sh](https://platform.sh) is a key supporter and funder of DDEV. They generously stepped in to and to become the lead sponsor of DDEV and to rescue the "DDEV" trademark and its use [in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md).
+As many of you know, [Platform.sh](https://platform.sh) is a key supporter and funder of DDEV. They generously stepped in to become the lead sponsor of DDEV and rescue the "DDEV" trademark and its use [in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md).
 
 Of course, time moves along and sometimes organizations have to change their priorities, and in 2025 Platform.sh has decided to change its approach, but still remains a generous lead sponsor at the _partner_ level. (Your organization can join them!)
 
@@ -27,7 +27,7 @@ As many of you know, though, times are tight in the agency world, and funding fo
 
 **THANKS to all of you who are supporting DDEV’s path to sustainability** and who have gotten your organizations to do so.
 
-**Stop by and thank Platform.sh** for their generous ongoing support of DDEV! See their [contact page](https://platform.sh/contact/) or join their [discord](https://discord.gg/platformsh).
+**Stop by and thank Platform.sh** for their generous ongoing support of DDEV! See their [contact page](https://platform.sh/contact/) or join their [Discord](https://discord.gg/platformsh).
 
 Want to keep up as the month goes along? Follow on
 

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -4,21 +4,20 @@ pubDate: 2025-01-03
 #modifiedDate: 2024-09-06
 summary: Changes in Platform.sh Funding of DDEV
 author: Randy Fay
-#featureImage:
-#  src: /img/blog/2024/12/nancy_lewis_colorado_river.jpg
-#  alt: Nancy Lewis painting of Colorado River near Palisade, Colorado
-#  credit: Nancy Lewis painting of the Colorado River near Palisade, Colorado
+featureImage:
+  src: /img/blog/2022/05/ddev-platformsh.jpg
+  alt: DDEV + Platform.sh
 categories:
   - Community
 ---
 
-As many of you know, [Platform.sh](https://platform.sh) is a key supporter and funder of DDEV. They generously stepped in to and to become the lead sponsor of DDEV and to rescue the "DDEV" trademark and its use [in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md). 
+As many of you know, [Platform.sh](https://platform.sh) is a key supporter and funder of DDEV. They generously stepped in to and to become the lead sponsor of DDEV and to rescue the "DDEV" trademark and its use [in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md).
 
-Of course, time moves along and sometimes organizations have to change their priorities, and in 2025 Platform.sh has decided to change its approach, but still remains a generous lead sponsor at the *partner* level. (Your organization can join them!)
+Of course, time moves along and sometimes organizations have to change their priorities, and in 2025 Platform.sh has decided to change its approach, but still remains a generous lead sponsor at the _partner_ level. (Your organization can join them!)
 
-* Instead of funding maintainer Randy Fay as an employee, Platform.sh will fund the DDEV Foundation with a generous 3000 Euros/month.
-* Platform.sh will transfer the "DDEV" trademark and control of the `ddev.com` and `ddev.site` domain names to the DDEV Foundation.
-* We'll continue to maintain the [ddev-platformsh](https://github.com/ddev/ddev-platformsh) add-on and explore an [Upsun](https://upsun.com) add-on.
+- Instead of funding maintainer Randy Fay as an employee, Platform.sh will fund the DDEV Foundation with a generous 3000 Euros/month.
+- Platform.sh will transfer the "DDEV" trademark and control of the `ddev.com` and `ddev.site` domain names to the DDEV Foundation.
+- We'll continue to maintain the [ddev-platformsh](https://github.com/ddev/ddev-platformsh) add-on and explore an [Upsun](https://upsun.com) add-on.
 
 We'll be preparing updated financial plans for 2025 to adjust to this change, and continue to be enormously thankful for the support of Platform.sh!
 

--- a/src/content/blog/platform-sh-ddev-funding-changes.md
+++ b/src/content/blog/platform-sh-ddev-funding-changes.md
@@ -5,8 +5,8 @@ pubDate: 2025-01-07
 summary: Changes in Platform.sh Funding of DDEV
 author: Randy Fay
 featureImage:
-  src: /img/blog/2022/05/ddev-platformsh.jpg
-  alt: DDEV + Platform.sh
+  src: "/img/blog/2022/05/ddev-platformsh.jpg"
+  alt: "DDEV + Platform.sh"
 categories:
   - Community
 ---
@@ -19,11 +19,13 @@ Of course, time moves along and sometimes organizations have to change their pri
 - Platform.sh will transfer the "DDEV" trademark and control of the `ddev.com` and `ddev.site` domain names to the DDEV Foundation.
 - We'll continue to maintain the [ddev-platformsh](https://github.com/ddev/ddev-platformsh) add-on and explore an [Upsun](https://upsun.com) add-on.
 
+We don't want to sugar-coat this too much. On the one hand, this is a reduction of about 60% in Platform's support of DDEV, and it will be an ongoing challenge to replace it. But on the other hand, Platform's generous ongoing support will still amount to about 50% of our total income.
+
 We'll be preparing updated financial plans for 2025 to adjust to this change, and continue to be enormously thankful for the support of Platform.sh!
 
-This change in funding mode will give DDEV more flexibility in use of funds, and is expected to be a solid move toward [full support for Stas Zhuk](lets-fund-stas-maintainer.md).
+This change in funding mode does give DDEV more flexibility in use of funds, and with the flexibility we can hope to move toward [full support for Stas Zhuk](lets-fund-stas-maintainer.md). The obvious problem is that now we have to budget for both Stas and Randy, with less resources.
 
-As many of you know, though, times are tight in the agency world, and funding for DDEV has actually declined in the last year, with several key sponsors having to back away. We hope you and your organization are coming up with new plans to support DDEV.
+As many of you know, though, times are tight in the agency world, and funding for DDEV has actually declined in other ways over the last year, with several key sponsors having to back away. We hope you and your organization are coming up with new plans to support DDEV.
 
 **THANKS to all of you who are supporting DDEV’s path to sustainability** and who have gotten your organizations to do so.
 


### PR DESCRIPTION
## The Issue

Blog announcing change in Platform.sh sponsorship

Rendered at https://20241226-platformsh-changes.ddev-com-front-end.pages.dev/blog/platform-sh-ddev-funding-changes/

I'm pretty sure we once had a "DDEV + Platformsh header image, but it seems it was lost in https://github.com/ddev/ddev.com/commit/23339600a34a842c52eb19584a291971a58852c9


