### PR TITLE
Remove more expired sponsors from featured sponsors list

### DIFF
--- a/src/featured-sponsors.json
+++ b/src/featured-sponsors.json
@@ -27,15 +27,7 @@
     "github": "i-gelb",
     "isLeading": false
   },
-  {
-    "name": "Open Strategy Partners",
-    "type": "major",
-    "logo": "/logos/OSP_logo_black_RGB.svg",
-    "darklogo": "/logos/OSP_logo_white_RGB.svg",
-    "squareLogo": "/logos/OSP_logo_black_RGB.svg",
-    "url": "https://openstrategypartners.com/",
-    "github": "open-strategy-partners"
-  },
+
   {
     "name": "Agaric",
     "type": "standard",
@@ -72,15 +64,7 @@
     "url": "https://centarro.io/",
     "github": "centarro"
   },
-  {
-    "name": "Fame Helsinki",
-    "type": "standard",
-    "logo": "/logos/fame-logo.svg",
-    "darklogo": "/logos/fame-darkmode.svg",
-    "squareLogo": "/logos/fame-square.svg",
-    "url": "https://fame.fi/",
-    "github": "FameHelsinki"
-  },
+
   {
     "name": "Gizra",
     "type": "standard",


### PR DESCRIPTION
## The Issue

Unfortunately, more sponsors have stepped back.

## How This PR Solves The Issue

Remove FameHelsinki and OSP. 

Related:
* #273 

Review at https://20250103-remove-inactive-spo.ddev-com-front-end.pages.dev/#supporters