### PR TITLE
Add .well-known funding-manifest-urls link for funding.json

### DIFF
--- a/public/.well-known/funding-manifest-urls
+++ b/public/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://github.com/ddev/ddev/tree/master/funding.json


### PR DESCRIPTION
## The Issue

Adding funding.json per https://floss.fund

Needs .well-known URL to point back to funding.json

## Manual Testing Instructions

Visit https://20250105-add-well-known.ddev-com-front-end.pages.dev/.well-known/funding-manifest-urls

`curl https://20250105-add-well-known.ddev-com-front-end.pages.dev/.well-known/funding-manifest-urls`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

