### PR TITLE
docs: add server.cors option for Vite (security)

### DIFF
--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -1,7 +1,7 @@
 ---
 title: "Working with Vite in DDEV - an introduction"
 pubDate: 2023-11-08
-modifiedDate: 2024-24-10
+modifiedDate: 2025-01-30
 summary: Working with Vite in DDEV
 author: Matthias Andrasch
 featureImage:
@@ -515,7 +515,7 @@ export default defineConfig({
         // this will also be used for the public/hot file (Vite devserver URL)
         origin: origin,
 
-      // needed for Vite >= v6.0.9
+       // needed for Vite >= v6.0.9
        cors: { origin: process.env.DDEV_PRIMARY_URL },
 
     }

--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -74,8 +74,7 @@ In order to use Vite in our DDEV projects, we generally need to do two things:
        strictPort: true,
        // Defines the origin of the generated asset URLs during development
        origin: origin,
-
-       // needed for Vite >= v6.0.9
+       // Configure CORS for the dev server (security)
        cors: { origin: process.env.DDEV_PRIMARY_URL },
      },
    })
@@ -239,7 +238,7 @@ export default defineConfig({
     // Defines the origin of the generated asset URLs during development
     origin: origin,
 
-    // needed for Vite >= v6.0.9
+    // Configure CORS for the dev server (security)
     cors: { origin: process.env.DDEV_PRIMARY_URL },
   },
 })
@@ -514,10 +513,8 @@ export default defineConfig({
         // Defines the origin of the generated asset URLs during development,
         // this will also be used for the public/hot file (Vite devserver URL)
         origin: origin,
-
-       // needed for Vite >= v6.0.9
-       cors: { origin: process.env.DDEV_PRIMARY_URL },
-
+        // Configure CORS for the dev server (security)
+        cors: { origin: process.env.DDEV_PRIMARY_URL },
     }
 });
 ```

--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -74,6 +74,9 @@ In order to use Vite in our DDEV projects, we generally need to do two things:
        strictPort: true,
        // Defines the origin of the generated asset URLs during development
        origin: origin,
+
+       // needed for Vite >= v6.0.9
+       cors: { origin: process.env.DDEV_PRIMARY_URL },
      },
    })
    ```
@@ -142,7 +145,7 @@ The final `package.json` is as follows:
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "vite": "^4.5.0"
+    "vite": "^6.0.11"
   }
 }
 ```
@@ -235,6 +238,9 @@ export default defineConfig({
     strictPort: true,
     // Defines the origin of the generated asset URLs during development
     origin: origin,
+
+    // needed for Vite >= v6.0.9
+    cors: { origin: process.env.DDEV_PRIMARY_URL },
   },
 })
 ```
@@ -507,7 +513,11 @@ export default defineConfig({
         strictPort: true,
         // Defines the origin of the generated asset URLs during development,
         // this will also be used for the public/hot file (Vite devserver URL)
-        origin: origin
+        origin: origin,
+
+      // needed for Vite >= v6.0.9
+       cors: { origin: process.env.DDEV_PRIMARY_URL },
+
     }
 });
 ```


### PR DESCRIPTION
## The Issue

- Vite changed the default cors security behavior to fix https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6, Patched versions: >=6.0.9, >=5.4.12, <6.0.0, >=4.5.6, <5.0.0

- see https://discord.com/channels/664580571770388500/1334261207049310230

## How This PR Solves The Issue

- add fix by @tyler36 

```
export default defineConfig({
// ...
    server: {
      // ...
        cors: { origin: process.env.DDEV_PRIMARY_URL },
```
## Manual Testing Instructions

## Automated Testing Overview

## Related Issue Link(s)

- https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6

## Release/Deployment Notes
