### PR TITLE
Remove gitpod support suggestions

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -55,7 +55,7 @@ import { CloudIcon } from "@heroicons/react/24/solid/index.js"
           <span class="w-4 h-4 inline-block mr-1 relative top-[2px]"
             ><CloudIcon />
           </span>Cloud
-          <Badge>Codespaces</Badge><Badge>Gitpod</Badge>
+          <Badge>Codespaces</Badge>
         </li>
       </ul>
     </div>

--- a/src/components/quickstart/Cloud.astro
+++ b/src/components/quickstart/Cloud.astro
@@ -18,28 +18,7 @@ const { latestVersion } = Astro.props
     Provider &amp; Install DDEV
   </h2>
 
-  <Tabs order={["Gitpod", "GitHub Codespaces"]}>
-    <Fragment slot="Gitpod">
-      <div class="prose pt-5 dark:prose-invert">
-        <p>
-          <a href="https://www.gitpod.io/docs/getting-started" target="_blank"
-          >Open any repository</a
-          > using Gitpod and install DDEV:
-        </p>
-        <Terminal
-          code={`→ curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/ddev.gpg > /dev/null\n→ echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null\n→ sudo apt-get update && sudo apt-get install -y ddev
-`}
-        />
-      </div>
-      <a href="https://gitpod.io/#https://github.com/ddev/ddev"
-        target="_blank"
-        ><img
-          src="/img/open-in-gitpod.svg"
-          alt="Open in Gitpod"
-          class="drop-shadow-sm pb-4 my-4"
-        />
-      </a>
-    </Fragment>
+  <Tabs order={["GitHub Codespaces"]}>
     <Fragment slot="GitHub Codespaces">
       <div class="prose py-5 dark:prose-invert">
         <ol>
@@ -87,13 +66,7 @@ const { latestVersion } = Astro.props
 
   <p>Confirm that you’ve now got DDEV installed: 🎉</p>
   <Terminal code={`→ ddev -v\nddev version ${latestVersion}`} />
-  
-  <p>
-    Or use the <a href="https://ddev.github.io/ddev-gitpod-launcher/" target="_blank">ddev-gitpod-launcher</a> form to launch a repository.
-    You’ll provide a source repository and click a button to open a newly-established environment.
-    You can specify a companion artifacts repository and automatically load <code>db.sql.gz</code> and <code>files.tgz</code> from it.
-    (More details in the <a href="https://github.com/ddev/ddev-gitpod-launcher/blob/main/README.md" target="_blank">repository’s README</a>.)
-  </p>
+
 </div>
 
 <Examples itemNumber="2/2" terminalType="default" terminalSymbol="→" />

--- a/src/content/blog/docker-desktop-alternatives-arrive-for-ddev-colima.md
+++ b/src/content/blog/docker-desktop-alternatives-arrive-for-ddev-colima.md
@@ -1,16 +1,17 @@
 ---
 title: "Docker Desktop Alternatives Arrive for DDEV (Colima!)"
 pubDate: 2022-03-25
-summary: The pros and cons of DDEV’s new support for Colima.
+modifiedDate: 2025-02-25
+summary: The pros and cons of DDEV’s support for Colima.
 author: Randy Fay
 categories:
   - Announcements
   - DevOps
 ---
 
-I’m sure you already know that Docker Desktop [changed its license terms](https://www.docker.com/blog/updating-product-subscriptions/) so that larger organizations are required to pay a per-seat license fee to use it now. We all hope that Docker does well and certainly there’s nothing wrong with an organization charging for its work, but there are many organizations that are uncomfortable with this stance for various reasons, or who would prefer to use open-source solutions rather than closed-source solutions like Docker Desktop.
+I’m sure you know that Docker Desktop [changed its license terms](https://www.docker.com/blog/updating-product-subscriptions/) so that larger organizations are required to pay a per-seat license fee to use it now. We all hope that Docker does well and certainly there’s nothing wrong with an organization charging for its work, but there are many organizations that are uncomfortable with this stance for various reasons, or who would prefer to use open-source solutions rather than closed-source solutions like Docker Desktop.
 
-In v1.19, DDEV supports alternative Docker solutions for every platform, so that it’s no longer necessary to use Docker Desktop at all. And these solutions seem to be more robust and more performant.
+In v1.19+, DDEV supports alternative Docker solutions for every platform, so that it’s no longer necessary to use Docker Desktop at all. And these solutions seem to be more robust and more performant.
 
 ## macOS: Colima
 
@@ -45,8 +46,4 @@ If you install Docker inside the WSL2 distro, you do not need Docker Desktop at 
 
 ## Linux: Do What You’ve Always Done
 
-On Linux, the solution has always been open-source and there is no license fee (see [docs](https://ddev.readthedocs.io/en/stable/users/docker%5Finstallation/#linux-installation-docker)). (Note that Docker has recently introduced Docker Desktop for Linux… I’m sure this works, but it will then involve closed-source and license fees.)
-
-## Don’t Forget Gitpod – You don’t need _anything_ installed on your computer
-
-In the midst of all this, don’t forget that you don’t need to install Docker (or anything else) on your computer or tablet to use DDEV. You can use [Gitpod](https://www.gitpod.io) in your browser all day in many ways. There are plenty of people who are now working this way. It works great. [DDEV provides full support](https://ddev.readthedocs.io/en/stable/users/topics/gitpod/) for Gitpod.
+On Linux, the solution has always been open-source and there is no license fee (see [docs](https://ddev.readthedocs.io/en/stable/users/docker%5Finstallation/#linux-installation-docker)). (Note that the separate GUI product "Docker Desktop for Linux" does not work with DDEV.)

--- a/src/content/blog/golang-debugging.md
+++ b/src/content/blog/golang-debugging.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging Golang (Go) Applications"
 pubDate: 2024-05-17
-modifiedDate: 2024-11-08
+modifiedDate: 2025-02-26
 summary: Debugging Golang applications using GoLand or VS Code
 author: Randy Fay
 featureImage:
@@ -78,10 +78,6 @@ VS Code debugging is a bit more tweaky. It seems that for commands, you need to 
 ### Running a test
 
 Running tests is almost exactly the same as in GoLand. Right-click the arrow next to the test function and choose "Run" or "Debug". The same caveats apply for `cmd` tests, you need `ddev` built from the same code in your `$PATH`.
-
-## Working in Gitpod
-
-Every DDEV PR and the main page has a launcher for Gitpod. Gitpod is just a Linux-based VS Code development environment in the cloud, in a browser. You can do everything you would want to do with it that you could do with VS Code locally. If you click the "Launch in Gitpod" button on any PR, that PR will be set up for you automatically in Gitpod, with all VS Code extensions already loaded, and with DDEV already compiled.
 
 ## Contributions welcome!
 

--- a/src/content/blog/maintaining-ddev-tests-contributor-training.md
+++ b/src/content/blog/maintaining-ddev-tests-contributor-training.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributor Training: Maintaining DDEV Automated Tests"
 pubDate: 2024-09-18
-# modifiedDate: 2024-07-23
+modifiedDate: 2025-02-26
 summary: Contributor training on maintaining and debugging DDEV automated tests.
 author: Randy Fay
 featureImage:
@@ -48,7 +48,7 @@ Flaky tests are the worst, because they may depend on the execution environment,
 
 - Review the test output from Buildkite or GitHub workflow to try to understand what's actually going on. There may be an earlier error that's reported that causes the actual failure.
 - Try to run it manually, perhaps step-debugging and introducing slower execution.
-- Try to run it on Gitpod, which is a more similar environment.
+- Try to run it on GitHub Codespaces, which is a more similar environment.
 - Try to run it using [tmate](https://github.com/mxschmitt/action-tmate) on the GitHub workflow, which is as close as you can get to the real test environment. (Tmate is built into each of the DDEV test workflows.)
 
 ### Fragile or brittle tests

--- a/src/content/blog/tmate-github-actions-contributor-training.md
+++ b/src/content/blog/tmate-github-actions-contributor-training.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributor Training: Tmate for Debugging GitHub Actions Workflows"
 pubDate: 2024-10-23
-# modifiedDate: 2024-10-23
+modifiedDate: 2025-02-26
 summary: Contributor training - Using tmate to debug and experiment with GitHub Actions.
 author: Randy Fay
 featureImage:
@@ -29,7 +29,7 @@ Often it's hard to understand what has happened with an test because all we see 
 ## Alternatives to Tmate
 
 1. We normally will try to understand a test failure by running it locally.
-2. Running in a similar Linux/AMD64 system like Gitpod is a pretty easy option.
+2. Running in a similar Linux/AMD64 system like GitHub Codespaceds is a pretty easy option.
 3. [nektos/act](https://github.com/nektos/act) is another recommended competitor to Tmate. It uses Docker and a Docker image to run an action on your local machine. I haven't had luck with it when I've tried it. See Stas's experience with `act` [below](#how-to-useact).
 
 ## Security Concerns

--- a/src/content/blog/whats-so-different-about-ddev-local.md
+++ b/src/content/blog/whats-so-different-about-ddev-local.md
@@ -1,7 +1,7 @@
 ---
 title: "What’s so different about DDEV?"
 pubDate: 2022-10-30
-modifiedDate: 2023-05-18
+modifiedDate: 2025-02-25
 summary: What makes DDEV stand out among other local development tools.
 author: Randy Fay
 featureImage:
@@ -11,7 +11,7 @@ categories:
   - DevOps
 ---
 
-In 2022, users from designers to developers to testers and open source contributors have a wide variety of local development environments to choose from. Because most of the tools and platforms we use will run in many different operating systems and environments, we have the option of rolling our own, using a commercial project like [MAMP](https://www.mamp.info/en/mamp-pro/mac/) or [Local](https://localwp.com/) (for WordPress), or using one of the many Docker-based solutions like [DDEV](https://ddev.readthedocs.io/), [Docksal](https://docksal.io/), or [Lando](https://lando.dev/).
+These days users from designers to developers to testers and open source contributors have a wide variety of local development environments to choose from. Because most of the tools and platforms we use will run in many different operating systems and environments, we have the option of rolling our own, using a commercial project like [MAMP](https://www.mamp.info/en/mamp-pro/mac/) or [Local](https://localwp.com/) (for WordPress), or using one of the many Docker-based solutions like [DDEV](https://ddev.readthedocs.io/), [Docksal](https://docksal.io/), or [Lando](https://lando.dev/).
 
 **But what’s so special about DDEV**? What makes it different from other Docker-based solutions like [Lando](https://lando.dev/) or [Docksal](https://docksal.io/)? I recently spent a little time exploring several similar platforms and was impressed with what I saw, but definitely came away wanting to highlight a number of DDEV features.
 
@@ -29,8 +29,7 @@ In 2022, users from designers to developers to testers and open source contribut
 - **Explicit support** for many of CMSs and platforms: TYPO3, Drupal/Backdrop, WordPress, Craft CMS, Magento, Laravel, and Shopware. Explicit support means settings management and an NGINX configuration customized for the specific platform.
 - **Easy use of other PHP and NodeJS platforms**, including Symfony, etc. While DDEV provides explicit support with optional settings management for many CMSs, many, many developers use other platforms and CMSs, including Symfony, Moodle, Mautic, etc. Explicit support of NodeJS versions for processing and as daemons.
 - **Library of supported, maintained, tested add-ons**, including Redis, Solr, Memcached, Elasticsearch, Mongo, Varnish.
-- **Full Gitpod support**: Your local development environment doesn’t even need to be local any more. DDEV has full support for use in [Gitpod](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#gitpod).
-- **Keeping up**: DDEV is always keeping up with the dependencies you need. For example, at this writing, neither PHP 8.2.0 nor Drupal 10 have yet been released, but both have been supported in DDEV for months. This is typical. DDEV had Linux ARM64 support before the mac M1 even came out, and had Apple Silicon support as soon as Docker Desktop supported it.
+- **Keeping up**: DDEV is always keeping up with the dependencies you need. For example, at this writing, neither PHP 8.2.0 nor Drupal 10 had yet been released, but both had been supported in DDEV for months. This is typical. DDEV had Linux ARM64 support before the mac M1 even came out, and had Apple Silicon support as soon as Docker Desktop supported it.
 - **Open-Source options for everything**: While most similar tools were once wedded to Docker Desktop, DDEV now provides alternate and fully-open-source Docker providers for every environment except traditional Windows. Those who do not want to pay for the Docker Desktop license do not have to do so.
 
 ## Plays well with others

--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -1,7 +1,7 @@
 ---
 title: "Working with Vite in DDEV - an introduction"
 pubDate: 2023-11-08
-modifiedDate: 2025-02-04
+modifiedDate: 2025-02-25
 summary: Working with Vite in DDEV
 author: Matthias Andrasch
 featureImage:
@@ -28,7 +28,6 @@ This articles sums up my current personal experience. I hope it will be a helpfu
   - [Laravel](#laravel)
   - [TYPO3](#typo3)
   - [WordPress](#wordpress)
-  - [Gitpod](#gitpod)
   - [GitHub Codespaces](#githubcodespaces)
 - [NodeJS / headless projects](#nodejs--headlessprojects)
 - [DDEV addons](#ddevaddons)
@@ -585,10 +584,6 @@ I experimented with Gitpod support for Vite in these demo projects, see:
 
 - [mandrasch/ddev-laravel-vite](https://github.com/mandrasch/ddev-laravel-vite)
 - [mandrasch/ddev-craftcms-vite](https://github.com/mandrasch/ddev-craftcms-vite)
-
-Note: On Gitpod, DDEVs router is not used - therefore some adjustments are needed. Exposing the port does not work via `.ddev/config.yaml`, instead you can use a docker-compose-file. See `docker-compose.vite-workaround.yaml` in the demo repositories.
-
-See [DDEV Installation: Gitpod](https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#gitpod) for more information.
 
 #### GitHub Codespaces
 

--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -578,13 +578,6 @@ Example repository for idleberg/php-wordpress-vite-assets, quick & dirty:
 
 - [mandrasch/ddev-wp-vite-demo](https://github.com/mandrasch/ddev-wp-vite-demo)
 
-#### Gitpod
-
-I experimented with Gitpod support for Vite in these demo projects, see:
-
-- [mandrasch/ddev-laravel-vite](https://github.com/mandrasch/ddev-laravel-vite)
-- [mandrasch/ddev-craftcms-vite](https://github.com/mandrasch/ddev-craftcms-vite)
-
 #### GitHub Codespaces
 
 I experimented with Codespaces support for Vite in these demo projects, see:


### PR DESCRIPTION
## The Issue

Followup task from
* https://github.com/ddev/ddev/pull/6974

Gitpod classic is no longer a thing. We've removed it from the docs, although it hasn't been removed from code.


Review:
* get-started page: https://20250225-remove-gitpod.ddev-com-front-end.pages.dev/get-started/
* Docker Desktop alternatives: https://20250225-remove-gitpod.ddev-com-front-end.pages.dev/blog/docker-desktop-alternatives-arrive-for-ddev-colima/
* What's so different about DDEV: https://20250225-remove-gitpod.ddev-com-front-end.pages.dev/blog/whats-so-different-about-ddev-local/
* https://20250225-remove-gitpod.ddev-com-front-end.pages.dev/blog/working-with-vite-in-ddev/

@mandrasch since I touched your vite article would appreciate you looking.