### PR TITLE
refactor: use `ddev add-on get`, references for add-on registry

### DIFF
--- a/src/content/blog/advanced-add-on-contributor-training.md
+++ b/src/content/blog/advanced-add-on-contributor-training.md
@@ -1,7 +1,7 @@
 ---
 title: "Contributor Training: Advanced Add-On Techniques"
 pubDate: 2024-07-23
-# modifiedDate: 2024-07-23
+modifiedDate: 2025-04-16
 summary: Advanced Add-On Techniques for Contributors
 author: Randy Fay
 featureImage:

--- a/src/content/blog/anatomy-advanced-ddev-addon.md
+++ b/src/content/blog/anatomy-advanced-ddev-addon.md
@@ -1,6 +1,7 @@
 ---
 title: "Diffy: Anatomy of an Advanced DDEV Add-on"
 pubDate: 2024-08-13
+modifiedDate: 2025-04-16
 summary: Custom container built for multiple architectures. Download the app and run "npm install" in the container.
 author: Yuri Gerasymov
 featureImage:

--- a/src/content/blog/ddev-diffy-introduction.md
+++ b/src/content/blog/ddev-diffy-introduction.md
@@ -1,6 +1,7 @@
 ---
 title: "Introduction: The Diffy DDEV plugin"
 pubDate: 2024-08-09
+modifiedDate: 2025-04-16
 summary: Visual regression testing tool Diffy got DDEV integration!
 author: Yuri Gerasymov
 featureImage:

--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -1,7 +1,7 @@
 ---
 title: "Working with Vite in DDEV - an introduction"
 pubDate: 2023-11-08
-modifiedDate: 2025-02-25
+modifiedDate: 2025-04-16
 summary: Working with Vite in DDEV
 author: Matthias Andrasch
 featureImage:


### PR DESCRIPTION
## The Issue

Some articles still use `ddev get`.

## How This PR Solves The Issue

- Replaces `ddev get` with `ddev add-on get`, see https://github.com/ddev/ddev/pull/6482
- Removes `ddev debug capabilities`, see https://github.com/ddev/ddev/issues/7174
- Adds more references for https://addons.ddev.com
- Replaces `addon` with `add-on`
- Replaces `NodeJS` with `Node.js`
- Adds missing languages for code blocks in the Vite article

## Manual Testing Instructions

- https://20250416-stasadev-addons.ddev-com-front-end.pages.dev/blog/advanced-add-on-contributor-training/
- https://20250416-stasadev-addons.ddev-com-front-end.pages.dev/blog/anatomy-advanced-ddev-addon/
- https://20250416-stasadev-addons.ddev-com-front-end.pages.dev/blog/ddev-diffy-introduction/
- https://20250416-stasadev-addons.ddev-com-front-end.pages.dev/blog/working-with-vite-in-ddev/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

