### PR TITLE
fix: use giscus only for blog pages, dark text color for 404

### DIFF
--- a/src/components/PostBody.astro
+++ b/src/components/PostBody.astro
@@ -6,7 +6,4 @@
 
 <div class="prose dark:prose-invert">
   <slot />
-
-  <giscus-comments></giscus-comments>
-  <script src="/src/scripts/giscus-comments.js"></script>
 </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,7 +7,7 @@ const title = `404`
 
 <Layout title={title} noindex={true} is404={true}>
   <main class="max-w-4xl mx-auto mb-24 px-6 lg:px-0">
-    <h1 class="font-mono text-5xl my-24 mb-8">{title}</h1>
+    <h1 class="font-mono text-5xl my-24 mb-8 dark:text-white">{title}</h1>
     <PostBody>
       <p>The page you’re looking for doesn’t exist. :(</p>
     </PostBody>

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -111,6 +111,8 @@ const blogPostSchema = [
       <div class="px-6 lg:px-0 lg:w-2/3">
         <PostBody>
           <Content />
+          <giscus-comments></giscus-comments>
+          <script src="/src/scripts/giscus-comments.js"></script>
         </PostBody>
       </div>
       <div class="px-6 lg:px-0 lg:w-1/3 lg:pl-24 mt-12 lg:mt-1">


### PR DESCRIPTION
## The Issue

Open https://ddev.com/foobar

- "404" text is black, but it should be white for dark theme.
-  Giscus comments shouldn't be here.

![image](https://github.com/user-attachments/assets/a4b89c0f-60c7-46ab-bb45-f86deb45abec)

## How This PR Solves The Issue

- Uses white text for 404 in dark mode.
- Uses Giscus only for blog pages.

## Manual Testing Instructions

Open https://20250512-stasadev-giscus.ddev-com-front-end.pages.dev/foobar

![image](https://github.com/user-attachments/assets/36d92f9a-9fca-4e27-b11b-280f26409b66)

Open blog page to make sure Giscus is still here https://20250512-stasadev-giscus.ddev-com-front-end.pages.dev/blog/ddev-may-2025-newsletter/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

