### PR TITLE
fix: set white tab hover color, show blog date in dark mode

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -89,7 +89,7 @@ const firstCategory = post.data.categories.length
             {post.data.author}
           </a>
         </p>
-        <div class="flex space-x-1 text-sm text-gray-600">
+        <div class="flex space-x-1 text-sm text-gray-600 dark:text-gray-300">
           <time datetime={post.data.pubDate}
             >{formatDate(post.data.pubDate)}</time
           >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -132,6 +132,10 @@ input[type="radio"]:checked + label {
 .tab {
   @apply px-3 py-1 leading-none font-mono font-bold text-sm text-gray-500 hover:text-black;
 
+  &:hover {
+    @apply dark:text-white;
+  }
+
   span {
     @apply border-dotted border-b border-gray-400;
   }


### PR DESCRIPTION
## The Issue

Hover color is wrong here https://ddev.com/get-started/

![before](https://github.com/user-attachments/assets/e2474de1-366c-4eff-a8ba-734b8a50d795)

And here https://ddev.com/blog/:

![image](https://github.com/user-attachments/assets/c6d0fc35-3494-4e86-a01c-4e560878be32)

## How This PR Solves The Issue

Sets white color on hover for dark mode:

![after](https://github.com/user-attachments/assets/0a623900-b06d-417b-a902-8e219df77c69)

And:

![image](https://github.com/user-attachments/assets/5a9f285d-ced1-4070-b584-e86f18629f45)

## Manual Testing Instructions

https://20250604-stasadev-hover-colo.ddev-com-front-end.pages.dev/get-started/
https://20250604-stasadev-hover-colo.ddev-com-front-end.pages.dev/blog/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

