### PR TITLE
Feature new Windows installer in get-started page for Windows

### DIFF
--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -45,14 +45,14 @@ const { latestVersion } = Astro.props
 
 <div class="prose dark:prose-invert">
   <h2 class="text-3xl mt-24">
-    <small class="block font-mono text-xs text-gray-500">2/3</small>  
+    <small class="block font-mono text-xs text-gray-500">2/3</small>
     Run the Installer
   </h2>
 
-  <p>Download the latest `ddev-windows-installer.exe` from <a href="https://github.com/ddev/ddev/releases">DDEV Releases</a>, and run it selecting the preferred "Docker CE" approach and selecting your "DDEV" distro.</p>
+  <p>Download the latest <code>ddev-windows-installer.exe</code> from <a href="https://github.com/ddev/ddev/releases">DDEV Releases</a>, and run it selecting the preferred "Docker CE" approach and selecting your "DDEV" distro.</p>
 
   <p>
-    In the “DDEV” terminal app or Windows Terminal, confirm that the "ddev" binary is
+    In the “DDEV” terminal app or Windows Terminal, confirm that the <code>ddev</code> binary is
     installed: 🎉
   </p>
   <Terminal
@@ -84,7 +84,7 @@ const { latestVersion } = Astro.props
 
   <p>
     Lastly, remove DDEV from Windows by visiting <i>Add or remove programs</i>,
-    finding “DDEV”, and choosing <i>Uninstall</i>. If you do not need the "DDEV" distro, you can also remove it by running `wsl --unregister DDEV`.
+    finding “DDEV”, and choosing <i>Uninstall</i>. If you do not need the "DDEV" distro, you can also remove it by running <code>wsl --unregister DDEV</code>.
   </p>
 
   <CommunityCTA />


### PR DESCRIPTION
## The Issue

We no longer need install script for Windows and instead use the installer. 

## How This PR Solves The Issue

Change the suggested approach

## Manual Testing Instructions

Rendered at https://20250716-windows-getting-sta.ddev-com-front-end.pages.dev/get-started/ (select "Windows")

## Related Issue Link(s)

* https://github.com/ddev/ddev/issues/7383

## Release/Deployment Notes

This should be done immediately on release of v1.24.7