### PR TITLE
refactor: update redirect rules

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,20 +1,28 @@
+# External redirects
 /install.sh https://raw.githubusercontent.com/ddev/ddev/main/scripts/install_ddev.sh 302
+
+# Short link redirects
 /s/port-conflict https://ddev.readthedocs.io/en/stable/users/usage/troubleshooting/#web-server-ports-already-occupied 301
 /s/discord https://discord.com/invite/5wjP76mBJD 301
-/ddev-local/ddev-wsl2-getting-started/ https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#windows 301
-/ddev-local/apache-solr-with-drupal-8-and-search-api-solr/ https://github.com/ddev/ddev-drupal9-solr 301
-/ddev-local/ddev-local-web-container-customization-in-v1-8-0/ https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ 301
-/ddev-local/ddev-local-nfs-mounting-setup-macos/ https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs 301
+/s/divide-and-conquer https://www.fldrupal.camp/session/divide-and-conquer-systematic-approach-troubleshooting-issues 301
+/s/divide-and-conquer-drupal4gov https://docs.google.com/presentation/d/1_OyAwQGTtz9xv1e_Qzau4Rarum5xQpPy0uS7ntA9leI/edit?usp=sharing 301
+
+# Generic blog redirects
 /ddev-local /blog 301
-/ddev-local/ /blog 301
+/ddev-local/* /blog/:splat/ 301
+/blog/:slug /blog/:slug/ 301
+
+# Removed blog post redirects, add trailing slashes here to make it work properly
+/blog/ddev-wsl2-getting-started/ https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#ddev-installation-windows 301
+/blog/apache-solr-with-drupal-8-and-search-api-solr/ https://github.com/ddev/ddev-drupal-solr 301
+/blog/ddev-local-web-container-customization-in-v1-8-0/ https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ 301
+/blog/ddev-local-nfs-mounting-setup-macos/ https://ddev.readthedocs.io/en/stable/users/install/performance/#filesystem-performance-nfs 301
+/blog/ddev-local-and-phpstorm-debugging-with-wsl2/ https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#phpstorm-debugging-setup 301
+
+# Authors redirects
 /meet-the-team /blog/authors 301
 /meet-the-team/ /blog/authors 301
+/blog/author/ /blog/authors 301
 /author/heather /blog/author/heather-mcnamee 301
 /author/rfay /blog/author/randy-fay 301
 /author/rmanelius /blog/author/rick-manelius 301
-/ddev-local/:slug /blog/:slug 301
-/ddev-local/:slug/ /blog/:slug 301
-/s/divide-and-conquer https://www.fldrupal.camp/session/divide-and-conquer-systematic-approach-troubleshooting-issues 301
-/s/divide-and-conquer-drupal4gov https://docs.google.com/presentation/d/1_OyAwQGTtz9xv1e_Qzau4Rarum5xQpPy0uS7ntA9leI/edit?usp=sharing 301
-/blog/ddev-local-and-phpstorm-debugging-with-wsl2 https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#phpstorm-debugging-setup 301
-/blog/ddev-local-and-phpstorm-debugging-with-wsl2/ https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#phpstorm-debugging-setup 301

--- a/src/pages/blog/authors.astro
+++ b/src/pages/blog/authors.astro
@@ -26,7 +26,7 @@ const title = `Blog Authors`
     >
       {
         activeAuthors.map((author) => (
-          <div>
+          <div class="dark:text-white">
             <a href={`/blog/author/${author.id}`}>{author.data.name}</a>
           </div>
         ))


### PR DESCRIPTION
## The Issue

Not all redirects worked properly with/without trailing slashes.

## How This PR Solves The Issue

- Groups redirects for better readability
- Adds proper redirects for `/ddev-local` and `/blog`
- Fixes black text on dark background in `/blog/authors`

## Manual Testing Instructions

All 4 links should be properly redirected:

- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/ddev-local/ddev-local-and-phpstorm-debugging-with-wsl2`
- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/ddev-local/ddev-local-and-phpstorm-debugging-with-wsl2/`
- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/blog/ddev-local-and-phpstorm-debugging-with-wsl2`
- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/blog/ddev-local-and-phpstorm-debugging-with-wsl2/`

Also:

- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/blog/author`
- `https://20250721-stasadev-redirects.ddev-com-front-end.pages.dev/blog/author/`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

