### PR TITLE
fix: update redirect rules, for #396

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -10,14 +10,18 @@
 
 # Generic blog redirects
 /ddev-local /blog 301
-/ddev-local/* /blog/:splat/ 301
-/blog/:slug /blog/:slug/ 301
+/ddev-local/* /blog/:splat 301
 
-# Removed blog post redirects, add trailing slashes here to make it work properly
+# Removed blog post redirects (add both links with and without trailing slash)
+/blog/ddev-wsl2-getting-started https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#ddev-installation-windows 301
 /blog/ddev-wsl2-getting-started/ https://ddev.readthedocs.io/en/stable/users/install/ddev-installation/#ddev-installation-windows 301
+/blog/apache-solr-with-drupal-8-and-search-api-solr https://github.com/ddev/ddev-drupal-solr 301
 /blog/apache-solr-with-drupal-8-and-search-api-solr/ https://github.com/ddev/ddev-drupal-solr 301
+/blog/ddev-local-web-container-customization-in-v1-8-0 https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ 301
 /blog/ddev-local-web-container-customization-in-v1-8-0/ https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/ 301
+/blog/ddev-local-nfs-mounting-setup-macos https://ddev.readthedocs.io/en/stable/users/install/performance/#filesystem-performance-nfs 301
 /blog/ddev-local-nfs-mounting-setup-macos/ https://ddev.readthedocs.io/en/stable/users/install/performance/#filesystem-performance-nfs 301
+/blog/ddev-local-and-phpstorm-debugging-with-wsl2 https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#phpstorm-debugging-setup 301
 /blog/ddev-local-and-phpstorm-debugging-with-wsl2/ https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#phpstorm-debugging-setup 301
 
 # Authors redirects


### PR DESCRIPTION
## The Issue

From Drupal Slack https://drupal.slack.com/archives/C5TQRQZRR/p1753179781323759

`https://ddev.com/blog/rss.xml` is broken because it's redirected to `https://ddev.com/blog/rss.xml/`

Caused by:

- #396

## How This PR Solves The Issue

Doesn't use so aggressive redirects.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

