### PR TITLE
docs: add command to update wsl for Windows

### DIFF
--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -32,13 +32,11 @@ const { latestVersion } = Astro.props
 
   <p>You’ll probably need to reboot.</p>
 
-  <p>After reboot, update your WSL:</p>
+  <p>If you had previously installed WSL, update it:</p>
 
   <Terminal type="powershell" code={`> wsl --update`} />
-
-  <p>Keeping WSL updated helps to ensure that DDEV installs successfully.</p>
-
-  <p>Then, install an Ubuntu distro:</p>
+  
+  <p>Then, install an Ubuntu distro named "DDEV":</p>
 
   <Terminal type="powershell" code={`> wsl --install Ubuntu --name DDEV`} />
   

--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -32,7 +32,13 @@ const { latestVersion } = Astro.props
 
   <p>You’ll probably need to reboot.</p>
 
-  <p>After reboot, install an Ubuntu distro:
+  <p>After reboot, update your WSL:</p>
+
+  <Terminal type="powershell" code={`> wsl --update`} />
+
+  <p>Keeping WSL updated helps to ensure that DDEV installs successfully.</p>
+
+  <p>Then, install an Ubuntu distro:</p>
 
   <Terminal type="powershell" code={`> wsl --install Ubuntu --name DDEV`} />
   


### PR DESCRIPTION
## The Issue

## How This PR Solves The Issue

When installing DDEV, I got an error message saying that DDEV can't be installed. After [a discussion and troubleshooting on Discord](https://discord.com/channels/664580571770388500/1397288639503007825), re-installing the WSL with `wsl --install` and updating with `wsl --update` solved the problem. DDEV was installed smoothly.

Based on this, in some cases, running `wsl --update` command after installing WSL on Windows might be required to install DDEV successfully. 

This PR adds the command to the [Get Started](https://ddev.com/get-started/) page.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

