### PR TITLE
feat: add short link for `addon-update-checker.sh`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,6 +7,7 @@
 /s/divide-and-conquer https://www.fldrupal.camp/session/divide-and-conquer-systematic-approach-troubleshooting-issues 301
 /s/divide-and-conquer-drupal4gov https://docs.google.com/presentation/d/1_OyAwQGTtz9xv1e_Qzau4Rarum5xQpPy0uS7ntA9leI/edit?usp=sharing 301
 /s/divide-conquer-dcco https://docs.google.com/presentation/d/1JBSXLP59E8DSzkvxqPPKuceQ_fSMXoW_tySs_jXe8Pg/edit?usp=sharing 301
+/s/addon-update-checker.sh https://raw.githubusercontent.com/ddev/ddev-addon-template/main/.github/scripts/update-checker.sh 301
 
 # Generic blog redirects
 /ddev-local /blog 301

--- a/src/content/blog/ddev-add-on-maintenance-guide.md
+++ b/src/content/blog/ddev-add-on-maintenance-guide.md
@@ -20,6 +20,12 @@ As part of preparing this guide, I also updated all official DDEV add-ons to ref
 
 ## Recommendations for Add-on Maintainers
 
+Run the update checker script periodically in your add-on to verify it is up to date:
+
+```bash
+curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
+```
+
 Here are some high-level practices to follow:
 
 - Take inspiration from the [official add-ons](https://addons.ddev.com/), see how they're structured and follow similar practices
@@ -31,10 +37,6 @@ Here are some high-level practices to follow:
 - Use `#!/usr/bin/env bash` instead of `#!/bin/bash` at the top of your command scripts, it's more portable and works better across different environments.
 - Ensure your add-on cleans up after itself: both `ddev add-on get` and `ddev add-on remove` should be idempotent. All files added via `project_files` and `global_files` must include a `#ddev-generated` stanza to support proper removal
 - Remember to publish a new release after any update (unless it's just a `README.md` change)
-- Run the update checker in your add-on to ensure it is up to date:
-  ```bash
-  curl -fsSL https://raw.githubusercontent.com/ddev/ddev-addon-template/main/.github/scripts/update-checker.sh | bash
-  ```
 
 ## What's New in the DDEV Ecosystem
 


### PR DESCRIPTION
## The Issue

The link is too long and may migrate somewhere else in the future.

## How This PR Solves The Issue

Adds a short link.

## Manual Testing Instructions

Review https://20250804-stasadev-addon-upda.ddev-com-front-end.pages.dev/blog/ddev-add-on-maintenance-guide/

```
git clone https://github.com/ddev/ddev-redis
cd ddev-redis
curl -fsSL https://20250804-stasadev-addon-upda.ddev-com-front-end.pages.dev/s/addon-update-checker.sh | bash
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

