### PR TITLE
chore(giscus): disable reactions for the main post

### DIFF
--- a/src/scripts/giscus-comments.js
+++ b/src/scripts/giscus-comments.js
@@ -25,7 +25,7 @@ class GiscusComments extends HTMLElement {
       script.setAttribute("data-category-id", "DIC_kwDON5ODtM4CnDbQ")
       script.setAttribute("data-mapping", "title")
       script.setAttribute("data-strict", "1")
-      script.setAttribute("data-reactions-enabled", "1")
+      script.setAttribute("data-reactions-enabled", "0")
       script.setAttribute("data-emit-metadata", "0")
       script.setAttribute("data-input-position", "top")
       script.setAttribute("data-theme", theme)


### PR DESCRIPTION
## The Issue

When someone adds a first reaction to a blog post with Giscus, we receive an empty email. This is annoying.

## How This PR Solves The Issue

Disables these reactions.

## Manual Testing Instructions

Before:
https://ddev.com/blog/ddev-august-2025-newsletter/
<img width="654" height="497" alt="image" src="https://github.com/user-attachments/assets/7257977c-7b6d-4a83-b435-6786ba598f92" />


After:
https://20250813-stasadev-giscus-rea.ddev-com-front-end.pages.dev/blog/ddev-august-2025-newsletter/
<img width="623" height="396" alt="image" src="https://github.com/user-attachments/assets/3baf9c31-10a4-4aae-87a4-8fb51109042d" />


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

