### PR TITLE
feat: add "Download Windows Installer" button, fixes ddev/ddev#7524

### DIFF
--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -52,7 +52,7 @@ const { latestVersion } = Astro.props
 
   <div class="not-prose mb-6">
     <CtaButton
-      text="Download Windows Installer →" 
+      text="Download Windows Installer ↓" 
       href={`https://github.com/ddev/ddev/releases/download/${latestVersion}/ddev_windows_amd64_installer.${latestVersion}.exe`}
     />
   </div>

--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -2,6 +2,7 @@
 import Terminal from "@components/Terminal.astro"
 import CommunityCTA from "./CommunityCTA.astro"
 import Examples from "./Examples.astro"
+import CtaButton from "@components/CtaButton.astro"
 
 export interface Props {
   latestVersion: string
@@ -49,7 +50,14 @@ const { latestVersion } = Astro.props
     Run the Installer
   </h2>
 
-  <p>Download the latest <code>ddev-windows-installer.exe</code> from <a href="https://github.com/ddev/ddev/releases">DDEV Releases</a>, and run it selecting the preferred "Docker CE" approach and selecting your "DDEV" distro.</p>
+  <div class="not-prose mb-6">
+    <CtaButton
+      text="Download Windows Installer →" 
+      href={`https://github.com/ddev/ddev/releases/download/${latestVersion}/ddev_windows_amd64_installer.${latestVersion}.exe`}
+    />
+  </div>
+  
+  <p>Run the installer selecting the preferred "Docker CE" approach and selecting your "DDEV" distro. You can also find all releases at <a href="https://github.com/ddev/ddev/releases">DDEV Releases</a>.</p>
 
   <p>
     In the “DDEV” terminal app or Windows Terminal, confirm that the <code>ddev</code> binary is


### PR DESCRIPTION
## The Issue

- ddev/ddev#7524

## How This PR Solves The Issue

Adds a big button for Windows Installer.

<img width="629" height="255" alt="image" src="https://github.com/user-attachments/assets/638e07ec-4bf4-4c64-bd2f-ae5124f66da4" />

## Manual Testing Instructions

Click the button https://20250825-stasadev-download-w.ddev-com-front-end.pages.dev/get-started/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

