### PR TITLE
feat: add feed links to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -67,6 +67,10 @@ const navigation = {
       me: true
     },
   ],
+  feeds: [
+    { name: "RSS", href: "/blog/rss.xml" },
+    { name: "JSON", href: "/blog/feed.json" },
+  ],
 }
 ---
 
@@ -74,7 +78,7 @@ const navigation = {
   <div class="max-w-4xl mx-auto py-12 px-6 lg:px-0 lg:py-16">
     <div class="pb-8 xl:grid xl:grid-cols-3 xl:gap-8">
       <div class="grid grid-cols-auto gap-8 xl:col-span-4">
-        <div class="md:grid md:grid-cols-4 md:gap-8">
+        <div class="md:grid md:grid-cols-2 lg:grid-cols-4 md:gap-8">
           <div class="mt-12 md:mt-0">
             <h2 class="text-sm font-mono text-navy-300 tracking-wider dark:text-navy-100">
               Support
@@ -134,6 +138,26 @@ const navigation = {
                         {item.name}
                       </a>
                     </li>
+                ))
+              }
+            </ul>
+          </div>
+          <div class="mt-12 md:mt-0">
+            <h2 class="text-sm font-mono text-navy-300 tracking-wider dark:text-navy-100">
+              Feeds
+            </h2>
+            <ul class="mt-4 space-y-4 dark:text-white">
+              {
+                navigation.feeds.map((item) => (
+                  <li>
+                    <a
+                      href={item.href}
+                      class="text-base"
+                      target={item.target || '_self'}
+                    >
+                      {item.name}
+                    </a>
+                  </li>
                 ))
               }
             </ul>


### PR DESCRIPTION
## The Issue

- #99
- https://github.com/ddev/ddev/issues/6929

## How This PR Solves The Issue

For Feedly users, it may be obvious how to set up an RSS feed, but I think we should link to RSS and JSON feeds in the footer so users know we have them.

Also, I recently broke the feed and didn't even know about it because I don't use it and we don't have a direct link to it:

- #402

This PR adds new links to ddev.com footer:

<img width="391" height="155" alt="image" src="https://github.com/user-attachments/assets/0dbf1138-3643-4b5f-a56a-31415120c263" />

## Manual Testing Instructions

https://20250925-stasadev-feed.ddev-com-front-end.pages.dev/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

