### PR TITLE
Minor edits: Use docs.ddev.com for URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,5 +256,5 @@ Production requires `GITHUB_TOKEN` environment variable in Cloudflare Pages sett
 ## Resources
 
 - [Astro Documentation](https://docs.astro.build)
-- [DDEV Documentation](https://ddev.readthedocs.io/)
+- [DDEV Documentation](https://docs.ddev.com/)
 - [Contributing to ddev.com Training](https://ddev.com/blog/ddev-website-for-contributors/)

--- a/src/content/blog/ddev-website-for-contributors.md
+++ b/src/content/blog/ddev-website-for-contributors.md
@@ -1,7 +1,7 @@
 ---
 title: "DDEV Website for Contributors"
 pubDate: 2023-08-15
-modifiedDate: 2023-08-23
+modifiedDate: 2025-10-09
 summary: Matt Stein on maintaining and improving ddev.com.
 author: Matt Stein
 featureImage:
@@ -16,7 +16,7 @@ The following is based on [Matt Stein's presentation outline](https://doc.mattst
 
 ## Welcome!
 
-I’d like to show you how ddev.com is put together so you can swoop in and improve it. There’s a lot that could be improved; The emphasis is on “what it is” rather than “how it should be.”
+I’d like to show you how `ddev.com` is put together so you can swoop in and improve it. There’s a lot that could be improved; The emphasis is on “what it is” rather than “how it should be.”
 
 ## Background
 
@@ -24,13 +24,13 @@ I’d like to show you how ddev.com is put together so you can swoop in and impr
 
 [**Matt**](https://github.com/mattstein) is a designer that’s been doing CMS-based development for clients using PHP, Twig, and different front-end frameworks; master of none fond of writing, documentation, and content strategy.
 
-[**ddev.com**](https://ddev.com) is a former WordPress site, tricky to share access and not the friendliest public welcome to all things DDEV.
+[**ddev.com**](https://ddev.com) used to be a WordPress site, tricky to share access and not the friendliest public welcome to all things DDEV.
 
 ### New Thing
 
-Rebuilt + migrated earlier this year to [Astro](https://astro.build)!
+Rebuilt + migrated in 2023 to [Astro](https://astro.build)!
 
-- Hat tip Mayank for sharing Astro with me.
+- Hat tip to Mayank for sharing Astro with me.
 - Fun to build with!
 - Static site generator that sits in a nice front-end sweet spot.
   - Flat file + fully accessible to front-end developers in a public repository.
@@ -44,7 +44,7 @@ Rebuilt + migrated earlier this year to [Astro](https://astro.build)!
   - [Tailwind CSS](https://tailwindcss.com) + [Tailwind Typography](https://tailwindcss.com/docs/typography-plugin).
   - Built and hosted with [Cloudflare Pages](https://pages.cloudflare.com).
 
-**tl;dr** if you’re comfortable with Markdown, HTML, CSS, Tailwind, or a modern front-end framework, you can jump right in!
+**tl;dr** if you’re comfortable with Markdown, HTML, CSS, Tailwind, or a modern front-end framework, you can jump right in! Blog posts and edits are even easier than that.
 
 <small>Also TypeScript, kind of.</small>
 
@@ -54,11 +54,11 @@ If you’re comfortable with _all_ of those things, you could make a big dent in
 
 Clone <https://github.com/ddev/ddev.com>.
 
-Add a GitHub key to `.env`.
+Add a GitHub key to `.env`. (optional)
 
 ## Where Content Lives
 
-> 💡 Consider reading [the readme](https://github.com/ddev/ddev.com/blob/main/README.md) and especially the [Astro docs](https://docs.astro.build/en/getting-started/).
+> 💡 Read [the README](https://github.com/ddev/ddev.com/blob/main/README.md) and especially the [Astro docs](https://docs.astro.build/en/getting-started/).
 
 Markdown, component markup, TypeScript constants, and a JSON blob.
 

--- a/src/content/blog/tailscale-router-ddev-addon.md
+++ b/src/content/blog/tailscale-router-ddev-addon.md
@@ -1,6 +1,7 @@
 ---
 title: "Tailscale for DDEV: Simple and Secure Project Sharing"
 pubDate: 2025-09-09
+modifiedDate: 2025-10-09
 summary: "Tired of temporary sharing links? Learn how to use the ddev-tailscale-router add-on to get a stable, secure, and private URL for your DDEV projects."
 author: Ajith Thampi Joseph
 featureImage:
@@ -123,8 +124,8 @@ Here are some additional resources that you might find helpful:
 - **[Tailscale Auth Keys](https://tailscale.com/kb/1085/auth-keys)**: Detailed information about creating and managing auth keys.
 - **[Tailscale Funnel](https://tailscale.com/kb/1223/funnel)**: Documentation on enabling public access to your Tailscale services.
 - **[Tailscale DNS](https://tailscale.com/kb/1054/dns)**: DNS in Tailscale
-- **[DDEV dotenv](https://ddev.readthedocs.io/en/latest/users/usage/commands/#dotenv)**: Documentation on managing environment variables with DDEV.
-- **[DDEV Docs: Sharing](https://ddev.readthedocs.io/en/latest/users/usage/sharing/)**: The official DDEV documentation on how to share your projects.
+- **[DDEV dotenv](https://docs.ddev.com/en/latest/users/usage/commands/#dotenv)**: Documentation on managing environment variables with DDEV.
+- **[DDEV Docs: Sharing](https://docs.ddev.com/en/latest/users/usage/sharing/)**: The official DDEV documentation on how to share your projects.
 - **Medium: [My Journey with PHP Dev Environments](https://medium.com/@josephajithampi/my-journey-with-php-dev-environments-1da9f2806ee9)**: A blog post on setting up a PHP development environment.
 - **LinkedIn: [The Day My Development Environment Nearly Broke Me](https://www.linkedin.com/pulse/day-my-development-environment-nearly-broke-me-how-i-thampi-joseph-ildhc/)**: An article on the importance of a reliable development environment.
 


### PR DESCRIPTION
This just fiddles with a tiny bit of content and uses
ddev.readthedocs.io -> docs.ddev.com

Rendered at https://pr-443.ddev-com-fork-previews.pages.dev/