### PR TITLE
Update old composer blog

### DIFF
--- a/src/content/blog/getting-started-with-ddev-and-composer.md
+++ b/src/content/blog/getting-started-with-ddev-and-composer.md
@@ -58,7 +58,7 @@ As the [documentation on ddev and Composer explains](https://docs.ddev.com/en/st
 
 `ddev composer create-project "drupal/recommended-project:^11" --stability dev --no-interaction`
 
-`ddev composer create-project "typo3/cms-base-distribution" . ^12`
+`ddev composer create-project "typo3/cms-base-distribution" . "^12"`
 
 `ddev composer require monolog/monolog`
 


### PR DESCRIPTION
The old composer blog needed update. We got an email about it, so might as well clean it up a bit. Most important, `ddev composer create` -> `ddev composer create-project`

Rendered at https://pr-449.ddev-com-fork-previews.pages.dev/blog/getting-started-with-ddev-and-composer/