### PR TITLE
Update support-ddev.astro with PayPal info, improve out-of-date content

### DIFF
--- a/src/pages/support-ddev.astro
+++ b/src/pages/support-ddev.astro
@@ -30,7 +30,7 @@ const title = `Support DDEV`
           <li><a href="#financial-support">🎯 Financial Support</a></li>
           <li><a href="#community-contributions">🤝 Community Contributions</a></li>
           <li><a href="#spread-the-word">📢 Spread the Word</a></li>
-          <li><a href="#make-a-difference">🌟 Make a Difference</a></li>
+          <li><a href="#make-a-difference">🌟 Ready to Make a Difference?</a></li>
         </ul>
       </section>
 


### PR DESCRIPTION
## The Issue

The paypal link is buried in the Github sponsors page.

## How This PR Solves The Issue

This makes it more prominent and updates some of the text for the the CTA at the bottom.

Rendered at https://pr-485.ddev-com-fork-previews.pages.dev/support-ddev/

