### PR TITLE
blog(newsletter): fix typo for default PHP version

### DIFF
--- a/src/content/blog/ddev-december-2025-newsletter.md
+++ b/src/content/blog/ddev-december-2025-newsletter.md
@@ -94,7 +94,7 @@ Passcode: 12345
 
 ## Sponsorship Update: Your Help is Needed
 
-With Upsun lowering their sponsorship in January, we'll drop from 70% to about 56% of our sponsorship goal. That's a significant gap.
+With Upsun lowering their sponsorship in January, we'll drop from 70% to about 58% of our sponsorship goal. That's a significant gap.
 
 **Previous status**: $8,376/month (70% of goal)
 


### PR DESCRIPTION
## The Issue

I noticed PHP 8.5 is mentioned as default in DDEV v1.25.0, but we're going to use PHP 8.4.

## How This PR Solves The Issue

## Manual Testing Instructions

https://pr-489.ddev-com-fork-previews.pages.dev/blog/ddev-december-2025-newsletter/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

