### PR TITLE
docs(codespaces): persist global config on codespaces, for ddev/ddev#6228

### DIFF
--- a/src/components/quickstart/Cloud.astro
+++ b/src/components/quickstart/Cloud.astro
@@ -38,6 +38,9 @@ const { latestVersion } = Astro.props
             "version": "latest"
         },
         "ghcr.io/ddev/ddev/install-ddev:latest": {}
+    },
+    "containerEnv": {
+        "XDG_CONFIG_HOME": "/workspaces/.config"
     }
 }
 `}


### PR DESCRIPTION
## The Issue

- ddev/ddev#6228

## How This PR Solves The Issue

Adds:

```json
"containerEnv": {
    "XDG_CONFIG_HOME": "/workspaces/.config"
}
```

## Manual Testing Instructions

Cloud Tab in https://pr-491.ddev-com-fork-previews.pages.dev/get-started/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

