### PR TITLE
fix(blog): use original filename for GitHub edit URL

### DIFF
--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -20,6 +20,12 @@ export async function getStaticPaths() {
 const { entry } = Astro.props
 const { Content, remarkPluginFrontmatter } = await render(entry)
 
+// Extract original filename from file path for GitHub edit URL
+// entry.id is URL-safe (dots removed), but we need the actual filename
+const originalFilename = entry.filePath
+  ? entry.filePath.split('/').pop().replace(/\.mdx?$/, '')
+  : entry.id
+
 const author = await getEntry("authors", getSlug(entry.data.author))
 
 const hasFeatureImage =
@@ -86,7 +92,7 @@ const blogPostSchema = [
       authorUrl={`/blog/author/${author.id}`}
       authorAvatar={authorImage}
       readTime={remarkPluginFrontmatter.minutesRead}
-      editUrl={GITHUB_URL_WEBSITE+`/`+entry.id+`.md`}
+      editUrl={GITHUB_URL_WEBSITE+`/`+originalFilename+`.md`}
     />
     {
       hasFeatureImage && shouldDisplayFeatureImage && (


### PR DESCRIPTION
## The Issue

404 link to https://github.com/ddev/ddev.com/tree/main/src/content/blog/release-v1250.md

<img width="869" height="440" alt="image" src="https://github.com/user-attachments/assets/fbe33949-73f2-4cf4-be78-4e41a34e7a31" />

## How This PR Solves The Issue

Fixes issue where blog posts with dots in filename (e.g., `release-v1.25.0.md`) had incorrect edit URLs. Astro's `entry.id` removes dots for URL safety, so we now extract the original filename from `entry.filePath` instead.

## Manual Testing Instructions

Click "Edit this page" in https://pr-528.ddev-com-fork-previews.pages.dev/blog/release-v1250/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

