### PR TITLE
fix: restore timestamps broken by remark-directive, for #530

### DIFF
--- a/src/lib/remark-callouts.mjs
+++ b/src/lib/remark-callouts.mjs
@@ -4,47 +4,60 @@ import { visit } from "unist-util-visit"
  * Remark plugin to transform directive nodes (:::tip, :::note, etc.) into styled callout boxes
  */
 export function remarkCallouts() {
+  const knownTypes = {
+    note: {
+      containerClass: "callout callout-note",
+      icon: "ℹ️",
+      title: "Note",
+    },
+    tip: {
+      containerClass: "callout callout-tip",
+      icon: "💡",
+      title: "Tip",
+    },
+    warning: {
+      containerClass: "callout callout-warning",
+      icon: "⚠️",
+      title: "Warning",
+    },
+    danger: {
+      containerClass: "callout callout-danger",
+      icon: "🚨",
+      title: "Danger",
+    },
+    info: {
+      containerClass: "callout callout-info",
+      icon: "ℹ️",
+      title: "Info",
+    },
+  }
+
   return (tree) => {
-    visit(tree, (node) => {
+    visit(tree, (node, index, parent) => {
       if (
         node.type === "containerDirective" ||
         node.type === "leafDirective" ||
         node.type === "textDirective"
       ) {
-        const data = node.data || (node.data = {})
-        const hast = data.hDirectiveLabel || {}
-        const type = node.name
+        const style = knownTypes[node.name]
 
-        // Map directive types to styles
-        const styles = {
-          note: {
-            containerClass: "callout callout-note",
-            icon: "ℹ️",
-            title: "Note",
-          },
-          tip: {
-            containerClass: "callout callout-tip",
-            icon: "💡",
-            title: "Tip",
-          },
-          warning: {
-            containerClass: "callout callout-warning",
-            icon: "⚠️",
-            title: "Warning",
-          },
-          danger: {
-            containerClass: "callout callout-danger",
-            icon: "🚨",
-            title: "Danger",
-          },
-          info: {
-            containerClass: "callout callout-info",
-            icon: "ℹ️",
-            title: "Info",
-          },
+        // Restore text/leaf directives that remark-directive parsed from
+        // normal content (e.g. `:00` from `[0:00](url)`, `::after` in CSS discussion)
+        if (node.type === "textDirective" || node.type === "leafDirective") {
+          const prefix = node.type === "textDirective" ? ":" : "::"
+          node.type = "text"
+          node.value = `${prefix}${node.name}`
+          delete node.data
+          delete node.name
+          delete node.attributes
+          delete node.children
+          return
         }
 
-        const style = styles[type] || styles.note
+        if (!style) return
+
+        const data = node.data || (node.data = {})
+        const hast = data.hDirectiveLabel || {}
 
         // Get the label from attributes or use default
         const label =


### PR DESCRIPTION
## The Issue

- #530

https://ddev.com/blog/watch-ddev-local-from-scratch-with-windows-wsl2/

<img width="626" height="227" alt="image" src="https://github.com/user-attachments/assets/16e58b33-5cad-48ee-8d0f-8d3c7a4d2401" />

## How This PR Solves The Issue

Fixes it by restoring the output:

https://pr-540.ddev-com-fork-previews.pages.dev/blog/watch-ddev-local-from-scratch-with-windows-wsl2/

<img width="498" height="86" alt="image" src="https://github.com/user-attachments/assets/e7dec9fd-cc2d-433c-b913-a67afd6d72e7" />

## Manual Testing Instructions

https://pr-540.ddev-com-fork-previews.pages.dev/blog/watch-ddev-local-from-scratch-with-windows-wsl2/

And compare these blogs (there should be no difference):
https://ddev.com/blog/markdown-features-demo/
https://pr-540.ddev-com-fork-previews.pages.dev/blog/markdown-features-demo/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

