### PR TITLE
fix: add horizontal scroll for wide tables

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -179,6 +179,12 @@ html.dark .terminal-wrapper .top-bar {
   }
 }
 
+/* Table containers - horizontal scroll on mobile */
+.prose table {
+  display: block;
+  overflow-x: auto;
+}
+
 /* Code block containers */
 .prose pre,
 pre.astro-code {


### PR DESCRIPTION
## The Issue

Podman blog looks weird in mobile view:

https://ddev.com/blog/podman-and-docker-rootless/

<img width="258" height="385" alt="1" src="https://github.com/user-attachments/assets/30b8c810-f77e-4b51-9c79-5fef993875d2" />

<img width="259" height="493" alt="2" src="https://github.com/user-attachments/assets/288ab337-11b4-4022-a077-3d35c7f1caa7" />

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

https://pr-541.ddev-com-fork-previews.pages.dev/blog/podman-and-docker-rootless/

<img width="406" height="438" alt="image" src="https://github.com/user-attachments/assets/c440206a-9c85-4edf-9683-94f19761ca70" />

<img width="407" height="478" alt="image" src="https://github.com/user-attachments/assets/053b5e6a-4eaf-41ad-99d4-800420721574" />


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

