### PR TITLE
fix: update image-size v2 API usage in featured-sponsors SVG pages, for #537

### DIFF
--- a/src/pages/resources/featured-sponsors-darkmode.svg.js
+++ b/src/pages/resources/featured-sponsors-darkmode.svg.js
@@ -49,7 +49,7 @@ const buildResponse = () => {
         }
 
         try {
-          const dimensions = sizeOf(logoPath)
+          const dimensions = sizeOf(fs.readFileSync(logoPath))
           const [width, height] = getScaledImageDimensions(
             dimensions.width,
             dimensions.height,
@@ -101,7 +101,7 @@ const buildResponse = () => {
     }
 
     try {
-      const dimensions = sizeOf(logoPath)
+      const dimensions = sizeOf(fs.readFileSync(logoPath))
       let [width, height] = getScaledImageDimensions(
         dimensions.width,
         dimensions.height,

--- a/src/pages/resources/featured-sponsors.svg.js
+++ b/src/pages/resources/featured-sponsors.svg.js
@@ -49,7 +49,7 @@ const buildResponse = () => {
         }
 
         try {
-          const dimensions = sizeOf(logoPath)
+          const dimensions = sizeOf(fs.readFileSync(logoPath))
           const [width, height] = getScaledImageDimensions(
             dimensions.width,
             dimensions.height,
@@ -101,7 +101,7 @@ const buildResponse = () => {
     }
 
     try {
-      const dimensions = sizeOf(logoPath)
+      const dimensions = sizeOf(fs.readFileSync(logoPath))
       let [width, height] = getScaledImageDimensions(
         dimensions.width,
         dimensions.height,


### PR DESCRIPTION
## The Issue

- #537

https://github.com/ddev/ddev.com/actions/runs/21946499863/job/63385381756#step:7:95

```
Error processing logo for Upsun: TypeError: The "list" argument must be an instance of SharedArrayBuffer, ArrayBuffer or ArrayBufferView.
    at TextDecoder.decode (node:internal/encoding:447:16)
    at toUTF8String (file:///home/runner/work/ddev.com/ddev.com/node_modules/image-size/dist/index.mjs:3:70)
    at Object.validate (file:///home/runner/work/ddev.com/ddev.com/node_modules/image-size/dist/index.mjs:49:24)
    at file:///home/runner/work/ddev.com/ddev.com/node_modules/image-size/dist/index.mjs:959:56
    at Array.find (<anonymous>)
    at detector (file:///home/runner/work/ddev.com/ddev.com/node_modules/image-size/dist/index.mjs:959:16)
    at imageSize (file:///home/runner/work/ddev.com/ddev.com/node_modules/image-size/dist/index.mjs:967:16)
    at file:///home/runner/work/ddev.com/ddev.com/dist/pages/resources/featured-sponsors-darkmode.svg.astro.mjs?time=1770899142243:73:26
    at Array.forEach (<anonymous>)
    at buildResponse (file:///home/runner/work/ddev.com/ddev.com/dist/pages/resources/featured-sponsors-darkmode.svg.astro.mjs?time=1770899142243:66:19) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

## How This PR Solves The Issue

`image-size` v2 (bumped by dependabot in #537) dropped support for passing a file path string to the synchronous `sizeOf()`. Pass a `Buffer` via `fs.readFileSync()` instead.

## Manual Testing Instructions

```bash
# no errors here
ddev npm run build
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

