### PR TITLE
fix: allow inline code to wrap on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -185,6 +185,11 @@ html.dark .terminal-wrapper .top-bar {
   overflow-x: auto;
 }
 
+/* Inline code - allow breaking long strings on mobile */
+.prose :not(pre) > code {
+  overflow-wrap: break-word;
+}
+
 /* Code block containers */
 .prose pre,
 pre.astro-code {


### PR DESCRIPTION
## The Issue

This is a follow-up for #541

https://ddev.com/blog/podman-and-docker-rootless/ still looks weird on smaller screens because of inline code

<img width="289" height="299" alt="image" src="https://github.com/user-attachments/assets/09c6da9a-6bac-4ffb-90f1-ef9911d88fc6" />

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

https://pr-543.ddev-com-fork-previews.pages.dev/blog/podman-and-docker-rootless/

<img width="334" height="522" alt="image" src="https://github.com/user-attachments/assets/9d76de1b-5890-4b5f-846f-00576fe2950e" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

