### PR TITLE
chore(ddev): update config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,36 +1,36 @@
-name: ddev.com
-type: php
+type: generic
 docroot: dist
-php_version: "8.1"
 webserver_type: nginx-fpm
-xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
+hooks:
+    post-start:
+        - exec: bash -c 'while [ ! -f /var/tmp/npm-install-done ]; do sleep 1; done'
+        - exec: bash -c 'if [ ! -d /var/www/html/dist ]; then npm run build; fi'
+        - exec: echo -e "                                  NOTICE                                        "
+        - exec: echo -e "================================================================================"
+        - exec: echo -e "The Astro dev container is ready"
+        - exec: echo -e "Hot Module Reloading (HMR) is available at \e[32m${DDEV_PRIMARY_URL_WITHOUT_PORT}:4321\e[0m"
+        - exec: echo -e "To troubleshoot any issues run \e[35mddev describe\e[0m or \e[35mddev logs --follow --time\e[0m"
+        - exec: echo -e "================================================================================"
+omit_containers: [db]
 use_dns_when_possible: true
-composer_version: "2"
 web_environment: []
 # nodejs_version auto reads from the .nvmrc
-nodejs_version: "auto"
-omit_containers: ["db"]
-disable_upload_dirs_warning: true
+nodejs_version: auto
+corepack_enable: false
 web_extra_exposed_ports:
     - name: astro-dev
       container_port: 4321
       http_port: 4322
       https_port: 4321
-# The extra -- in `npm run dev -- --host` is a Vite requirement
-# https://github.com/vitejs/vite/discussions/3396
 web_extra_daemons:
-  - name: astro-dev-daemon
-    command: bash -c 'npm install && touch /var/tmp/npminstalldone && npm run dev -- --host'
-    directory: /var/www/html
-hooks:
-  post-start:
-    - exec: bash -c 'while [ ! -f /var/tmp/npminstalldone ]; do sleep 1; done'
-    - exec: bash -c 'if [ ! -d /var/www/html/dist ]; then npm run build; fi'
-    - exec: echo -e "                                  NOTICE                                        \n
-                         =================================================================================\n
-                         =================================================================================\n
-                          The Astro dev container is ready \n
-                          Hot Module Reloadin (HMR) is avaliable at \e[32m${DDEV_PRIMARY_URL}:4321\e[0m \n
-                          To troubleshoot any isues run \e[35mddev describe\e[0m or \e[35mddev logs --follow --time\e[0m \n"
+    - name: astro-dev-daemon
+      # The extra -- in `npm run dev -- --host` is a Vite requirement
+      # See https://github.com/vitejs/vite/discussions/3396
+      # 4321 is the default port for Astro, set it explicitly anyway
+      # See https://docs.astro.build/en/reference/configuration-reference/#serverport
+      command: bash -c 'npm install && touch /var/tmp/npm-install-done && npm run dev -- --host --port 4321'
+      directory: /var/www/html
+disable_upload_dirs_warning: true
+ddev_version_constraint: '>= v1.24.10'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ Use DDEV for all development tasks:
 
 ### Site Access
 
-- Dev server: https://<projectname>.ddev.site:4321
-- Built site: https://<projectname>.ddev.site
+- Dev server: `https://<projectname>.ddev.site:4321`
+- Built site: `https://<projectname>.ddev.site`
 
 ### Testing and Quality
 
@@ -152,7 +152,7 @@ Featured sponsors are managed in `src/featured-sponsors.json` with specific sche
 ### DDEV Setup (Recommended)
 
 1. Run `ddev start` to start and set up the project's dependencies
-2. Open https://<projectname>.ddev.site:4321 in your browser
+2. Open `https://<projectname>.ddev.site:4321` in your browser
 3. To rebuild static site: `ddev npm run build`
 4. Static site available at: https://<projectname>.ddev.site
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ All commands are run from the root of the project, from a terminal:
 DDEV already has all the dependencies included.
 
 1. Run `ddev start` to start and set up the project’s dependencies.
-2. Open https://<projectname>.ddev.site:4321 in your browser
+2. Open `https://<projectname>.ddev.site:4321` in your browser.
 
-To rebuild a static copy of the site, run `ddev npm run build`. The contents of the `dist/` folder are what gets [deployed to Cloudflare Pages](#build--deployment) and can be found at https://<projectname>.ddev.site. The dev server runs on a web_extra_daemons, it includes Vite HMR (hot module reloading) among other features and it can be found at https://<projectname>.ddev.site:4321.
+To rebuild a static copy of the site, run `ddev npm run build`. The contents of the `dist/` folder are what gets [deployed to Cloudflare Pages](#build--deployment) and can be found at `https://<projectname>.ddev.site`. The dev server runs on a `web_extra_daemons`, it includes Vite HMR (hot module reloading) among other features, and it can be found at `https://<projectname>.ddev.site:4321`.
 
 Troubleshooting steps: Check `ddev logs`.
 


### PR DESCRIPTION
## The Issue

Our DDEV config is outdated.

## How This PR Solves The Issue

Removes:

- `name` - so it can be detected automatically from the enclosing directory
- `php_version` - not applicable to the project
- `xdebug_enabled` - not applicable to the project
- `composer_version`  - not applicable to the project

Changes:

- `type: php` -> `type: generic` for Node.js project

Adds:

- `corepack_enable: false` - related to Node.js, in case we are going to set it later
- `ddev_version_constraint: '>= v1.24.10'` - to get people to use the newer DDEV (without forcing v1.25.0 yet).

I didn't update https://github.com/ddev/ddev.com/blob/main/.nvmrc, opened #553

I ran `ddev config --auto` to arrange all the options as DDEV prefers it.

## Manual Testing Instructions

Run locally:

```bash
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

