### PR TITLE
docs: fix link to ddevcd section of docs

### DIFF
--- a/src/content/blog/release-v1.24.0-php8.4.md
+++ b/src/content/blog/release-v1.24.0-php8.4.md
@@ -22,7 +22,7 @@ Congratulations to **all of you and all contributors who made this happen**. It'
 
 ## New Features and other things we're proud of
 
-- `ddevcd` command can be used to switch between projects. See `ddev debug cd`. For example, if I have a project named `t3v12` I can do a `ddevcd t3v12` to switch to that directory. [Stas](https://github.com/stasadev) added this feature out of the blue and I love it. It does require a [tiny bit of one-time configuration](https://docs.ddev.com/en/stable/users/usage/commands/#debug-cd).
+- `ddevcd` command can be used to switch between projects. See `ddev debug cd`. For example, if I have a project named `t3v12` I can do a `ddevcd t3v12` to switch to that directory. [Stas](https://github.com/stasadev) added this feature out of the blue and I love it. It does require a [tiny bit of one-time configuration](https://docs.ddev.com/en/stable/users/usage/commands/#utility-cd).
 - `drupal11` is introduced as a project type, demoting the `drupal` project type to be a simple alias to the "latest stable Drupal version" (`drupal11` for now).
 - The `ddev-webserver` image is at least 25% smaller. Only a few locales are included by default, and only currently-supported versions of PHP are built-in by default (but all the other versions still work). It was 480MB compressed, is now 361MB compressed. More details below.
 - `ddev auth ssh` can now be used with individual key files and can follow symlinks. For example, if you only want to have a single file named `id_rsa` to be available to your projects, you can `ddev auth ssh -f ~/.ssh/id_rsa`.


### PR DESCRIPTION
## The Issue

The documentation link is to the top of the page.
This requires a reader to know where on the page to look or guess at keywords to search for.

## How This PR Solves The Issue

This update update the link to go directly to the relevant section in th docs.

## Manual Testing Instructions
Verify that the link to the `ddevcd` section directs to the correct documentation page.

## Automated Testing Overview
No automated tests are needed for this documentation change.

## Related Issue Link(s)

## Release/Deployment Notes
No additional deployment steps are required.

