### PR TITLE
docs(quickstart): add example for interactive dashboard

### DIFF
--- a/src/components/quickstart/Examples.astro
+++ b/src/components/quickstart/Examples.astro
@@ -58,14 +58,23 @@ const { itemNumber, terminalType, terminalSymbol } = Astro.props;
   </p>
 
   <p>
+    Run <code>ddev</code> with no arguments to open the <a
+      href="https://docs.ddev.com/en/stable/users/usage/cli/#interactive-dashboard"
+      target="_blank"
+      >interactive dashboard</a>, an overview of your projects and quick access to common actions:
+  </p>
+
+  <Terminal type={terminalType} code={`${terminalSymbol} ddev`} />
+
+  <p>
     Run the <a
       href="https://docs.ddev.com/en/stable/users/usage/commands/#help"
       target="_blank"
       >help command</a>
-    (or plain <code>ddev</code>) to see the actions you can take with the CLI:
+    (or <code>ddev -h</code>) to see the actions you can take with the CLI:
   </p>
 
-  <Terminal type={terminalType} code={`${terminalSymbol} ddev -h`} />
+  <Terminal type={terminalType} code={`${terminalSymbol} ddev help`} />
 
   <p>
     Use the <a

--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -149,14 +149,23 @@ const { latestVersion } = Astro.props
   </p>
 
   <p>
+    Run <code>ddev</code> with no arguments to open the <a
+      href="https://docs.ddev.com/en/stable/users/usage/cli/#interactive-dashboard"
+      target="_blank"
+      >interactive dashboard</a>, an overview of your projects and quick access to common actions:
+  </p>
+
+  <Terminal type={terminalType} code={`${terminalSymbol} ddev`} />
+
+  <p>
     Run the <a
       href="https://docs.ddev.com/en/stable/users/usage/commands/#help"
       target="_blank"
       >help command</a>
-    (or plain <code>ddev</code>) to see the actions you can take with the CLI:
+    (or <code>ddev -h</code>) to see the actions you can take with the CLI:
   </p>
 
-  <Terminal type={terminalType} code={`${terminalSymbol} ddev -h`} />
+  <Terminal type={terminalType} code={`${terminalSymbol} ddev help`} />
 
   <p>
     Use the <a


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/8144

<img width="631" height="363" alt="image" src="https://github.com/user-attachments/assets/f9d9b667-107a-4c22-84ab-afc1a5839fde" />

## How This PR Solves The Issue

Updates the example:

<img width="630" height="553" alt="image" src="https://github.com/user-attachments/assets/6d3c6562-4ad5-4ccb-9777-a57363dbf827" />

## Manual Testing Instructions

https://pr-567.ddev-com-fork-previews.pages.dev/get-started/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

