### PR TITLE
fix(vite): allow Coder workspace hosts and show Coder HMR URL

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,6 +11,7 @@ hooks:
         - exec: echo -e "================================================================================"
         - exec: echo -e "The Astro dev container is ready"
         - exec: echo -e "Hot Module Reloading (HMR) is available at \e[32m${DDEV_PRIMARY_URL_WITHOUT_PORT}:4321\e[0m"
+        - exec-host: "bash -c 'if [ -n \"${VSCODE_PROXY_URI:-}\" ]; then echo -e \"Coder HMR URL: \\e[32m$(echo $VSCODE_PROXY_URI | sed s/{{port}}/4322/)\\e[0m\"; fi'"
         - exec: echo -e "To troubleshoot any issues run \e[35mddev describe\e[0m or \e[35mddev logs --follow --time\e[0m"
         - exec: echo -e "================================================================================"
 omit_containers: [db]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to AI agents when working with code in this repository.
 
+## Tool Preferences
+
+- Prefer `jq` over Python for JSON processing in shell commands
+
 ## Communication Style
 
 - Use direct, concise language without unnecessary adjectives or adverbs

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,15 @@ export default defineConfig({
   site: "https://ddev.com",
   vite: {
     server: {
-      allowedHosts: ["." + process.env.DDEV_TLD], // leave this unchanged for DDEV!
+      allowedHosts: [
+        process.env.DDEV_TLD ? "." + process.env.DDEV_TLD : undefined,
+        // Allow Coder workspace hosts derived from VSCODE_PROXY_URI
+        // e.g. "https://{{port}}--main--ddev-com--rfay.coder.ddev.com" → ".coder.ddev.com"
+        process.env.VSCODE_PROXY_URI?.match(/^https?:\/\/[^.]+\.(.+)$/)?.[1]
+          ? "." +
+            process.env.VSCODE_PROXY_URI.match(/^https?:\/\/[^.]+\.(.+)$/)?.[1]
+          : undefined,
+      ].filter(Boolean),
     },
     // Configure CORS for the dev server (security)
     cors: { origin: process.env.DDEV_PRIMARY_URL },


### PR DESCRIPTION
## Summary

- **`astro.config.mjs`**: Fixes the Vite dev server blocking requests proxied through Coder. Extracts the domain suffix from `VSCODE_PROXY_URI` (e.g. `.coder.ddev.com`) and adds it to `allowedHosts`, so requests like `https://4322--main--ddev-com--rfay.coder.ddev.com` are accepted. No effect outside Coder environments.

- **`.ddev/config.yaml`**: Adds an `exec-host` post-start hook that prints the Coder-specific HMR URL when `VSCODE_PROXY_URI` is set. Outside Coder it is a no-op.

- **`AGENTS.md`**: Adds jq tool preference (prefer `jq` over Python for JSON processing in shell commands).

## Test plan

- [ ] `ddev restart` in a Coder workspace shows `Coder HMR URL: https://4322--...` in post-start output
- [ ] Browsing `https://4322--main--ddev-com--rfay.coder.ddev.com` returns 200 from the Vite dev server
- [ ] `ddev restart` outside Coder shows no Coder-specific output and HMR works normally at the DDEV URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)