### PR TITLE
build(astro): fix astro/toolbar, use Node.js v22 in build, for #588

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 
 jobs:
   build:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,6 +43,9 @@ export default defineConfig({
     // Configure CORS for the dev server (security)
     cors: { origin: process.env.DDEV_PRIMARY_URL },
     plugins: [tailwindcss()],
+    optimizeDeps: {
+      include: ["astro/toolbar"],
+    },
   },
   integrations: [
     react(),
@@ -69,6 +72,7 @@ export default defineConfig({
     prefetch(),
     mermaid({
       autoTheme: true,
+      enableLog: false,
     }),
   ],
   markdown: {


### PR DESCRIPTION
## The Issue

- For #588

When I opened dev tools in HMR, I noticed errors about astro/toolbar

## How This PR Solves The Issue

Fixes it according to:

- https://github.com/withastro/astro/issues/15857

Disables astro-mermaid logs.

Uses Node.js v22 in build too.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

