### PR TITLE
chore(commands): add #ddev-silent-no-warn

### DIFF
--- a/.ddev/commands/web/prettier
+++ b/.ddev/commands/web/prettier
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+#ddev-silent-no-warn
 ## Description: Run prettier inside the web container
 ## Usage: prettier
 ## Example: "ddev prettier"

--- a/.ddev/commands/web/textlint
+++ b/.ddev/commands/web/textlint
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+#ddev-silent-no-warn
 ## Description: Run textlint inside the web container
 ## Usage: textlint
 ## Example: "ddev textlint"


### PR DESCRIPTION
## The Issue

Using ddev/ddev#8218:

```
$ ddev start
Custom configuration detected in project 'ddev.com':
  • Commands:
    - /home/stas/code/ddev/ddev.com/.ddev/commands/web/prettier
    - /home/stas/code/ddev/ddev.com/.ddev/commands/web/textlint

Custom configuration is updated on restart. Run 'ddev restart' if changes don't take effect.
Add '#ddev-silent-no-warn' comment to files if you don't want to see these warnings.
```

## How This PR Solves The Issue

Adds `#ddev-silent-no-warn`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

