### PR TITLE
docs: expand WSL2 HTTPS trust model in trusted-https-certificates blog post (mostly right before DDEV v1.25.2)

### DIFF
--- a/src/content/blog/ddev-local-trusted-https-certificates.md
+++ b/src/content/blog/ddev-local-trusted-https-certificates.md
@@ -17,6 +17,8 @@ Security is critical on the modern web, and all sites should ideally be develope
 
 With [DDEV](http://github.com/ddev/ddev) you can use the HTTPS version of your project in a browser that trusts your project, without clicking through security warnings.
 
+## Table of Contents
+
 ## TL;DR
 
 You don't have to read or understand the rest of this :) There's a one-time installation of trusted HTTPS for DDEV:

--- a/src/content/blog/ddev-local-trusted-https-certificates.md
+++ b/src/content/blog/ddev-local-trusted-https-certificates.md
@@ -1,7 +1,7 @@
 ---
 title: "DDEV Trusted HTTPS Certificates"
 pubDate: 2019-05-23
-modifiedDate: 2026-03-28
+modifiedDate: 2026-04-17
 modifiedComment: Added WSL2 two-computer model explanation, CAROOT/WSLENV propagation, Firefox variant trust store caveats, and ddev utility tls-diagnose reference.
 summary: The importance of local HTTPS, and how to take advantage of it with DDEV.
 author: Randy Fay
@@ -21,7 +21,7 @@ With [DDEV](http://github.com/ddev/ddev) you can use the HTTPS version of your p
 
 You don't have to read or understand the rest of this :) There's a one-time installation of trusted HTTPS for DDEV:
 
-```
+```bash
 mkcert -install && ddev poweroff && ddev start
 ```
 
@@ -146,9 +146,9 @@ mkcert -CAROOT
 
 ### Firefox on Windows
 
-Firefox on Windows is a special case. Unlike Chrome and Edge, Firefox does **not** use the Windows system certificate store. It maintains its own trust store, so even a correctly configured CAROOT won't automatically make Firefox trust DDEV certificates.
+Modern Firefox on Windows can use the Windows system certificate store automatically. If you see certificate errors in Firefox on Windows, go to **Settings → Privacy & Security** and enable **"Allow Firefox to automatically trust third-party root certificates you install"**. This is usually all that is needed.
 
-To use DDEV with Firefox on Windows, you must manually import the CA:
+If that setting is already enabled and Firefox still shows errors, import the CA manually:
 
 1. Find the CA file: it's `rootCA.pem` inside the directory shown by `mkcert -CAROOT` (translated to a Windows path, e.g., `C:\Users\you\AppData\Local\mkcert\rootCA.pem`)
 2. In Firefox: **Settings → Privacy & Security → View Certificates → Authorities tab → Import**
@@ -156,32 +156,47 @@ To use DDEV with Firefox on Windows, you must manually import the CA:
 
 Firefox Nightly, Developer Edition, and ESR each maintain a **separate** trust store from standard Firefox. If you use any of these, repeat the import for each one.
 
-### Diagnosing WSL2 Certificate Problems
+### Diagnosing Certificate Problems
 
-DDEV v1.25.2 and later include a built-in diagnostic tool that checks every part of the certificate trust chain:
+DDEV v1.25.2 and later include a built-in diagnostic tool that checks every part of the certificate trust chain. It works on all platforms, not just WSL2:
 
 ```bash
+# Run from any directory for mkcert, trust store, and cert file checks
 ddev utility tls-diagnose
+
+# Run from a running project directory to also check live HTTPS connectivity
+cd my-project && ddev start && ddev utility tls-diagnose
 ```
 
 It checks:
 
 - `mkcert` installation and `CAROOT` path
-- Whether `CAROOT` points to the Windows filesystem
-- Whether `WSLENV` is configured correctly
-- Whether the mkcert CA is in the Windows certificate store
-- Whether your project certificates are valid and signed by the current CA
-- Whether Chrome/Edge would actually trust a live HTTPS request (via PowerShell `Invoke-WebRequest`)
+- OS trust store installation
+- Certificate file validity
+- Live HTTPS connectivity (when run from a running project directory)
 
-Run this first when something isn't working.
+On WSL2, it also checks:
+
+- Whether `CAROOT` points to the Windows filesystem
+- Whether `CAROOT` is in `WSLENV`
+- Whether the mkcert CA is in the Windows certificate store
+- Whether the Windows-side and WSL2-side CA fingerprints match
+
+Try this first when something isn't working.
 
 ## Troubleshooting
 
 ### Browsers Still Show Warnings
 
-Some browsers don't automatically pick up the system trust store. Firefox, in particular, maintains its own certificate store. Run `mkcert -install` which should handle Firefox, but if issues persist, see the [browser configuration documentation](https://docs.ddev.com/en/stable/users/install/configuring-browsers/).
+Run `ddev utility tls-diagnose` first — it identifies the specific problem and prints actionable fix instructions. (This was new in DDEV v1.25.2.)
 
-**WSL2 users**: run `ddev utility tls-diagnose` — it will tell you exactly what's wrong and how to fix it.
+Some browsers don't automatically pick up the system trust store. Firefox, in particular, sometimes maintains its own certificate store.
+
+- **Firefox on Windows**: enable **"Allow Firefox to automatically trust third-party root certificates you install"** in Settings → Privacy & Security. If that doesn't resolve it, see the [Firefox on Windows](#firefox-on-windows) section above for manual import steps.
+- **Firefox on Linux**: relies on `certutil` (from `libnss3-tools`) for `mkcert -install` to register the CA. Install it with `sudo apt install libnss3-tools`, then run `mkcert -install` again.
+- **Firefox Nightly, Developer Edition, ESR**: may maintain a separate trust store and need the manual CA import treatment.
+
+If issues persist, see the [browser configuration documentation](https://docs.ddev.com/en/stable/users/install/configuring-browsers/).
 
 ### cURL Doesn't Trust Certificates
 

--- a/src/content/blog/ddev-local-trusted-https-certificates.md
+++ b/src/content/blog/ddev-local-trusted-https-certificates.md
@@ -1,8 +1,8 @@
 ---
 title: "DDEV Trusted HTTPS Certificates"
 pubDate: 2019-05-23
-modifiedDate: 2025-11-15
-modifiedComment: Updated to explain Certificate Authorities, how mkcert installs the local CA, and troubleshooting steps for when automatic installation doesn't work. Added reference to detailed browser configuration documentation.
+modifiedDate: 2026-03-28
+modifiedComment: Added WSL2 two-computer model explanation, CAROOT/WSLENV propagation, Firefox variant trust store caveats, and ddev utility tls-diagnose reference.
 summary: The importance of local HTTPS, and how to take advantage of it with DDEV.
 author: Randy Fay
 featureImage:
@@ -24,6 +24,8 @@ You don't have to read or understand the rest of this :) There's a one-time inst
 ```
 mkcert -install && ddev poweroff && ddev start
 ```
+
+**WSL2 users:** the setup is a bit different — [see the WSL2 section below](#wsl2-the-two-computer-model).
 
 ## Understanding Certificate Authorities
 
@@ -68,13 +70,118 @@ mkcert -install
 
 **Windows**: Run `mkcert -install` and accept the dialog that pops up.
 
-## Troubleshooting
+**WSL2**: See the [WSL2 section below](#wsl2-the-two-computer-model) — the setup is more involved.
 
-If HTTPS doesn't work after installation, here are common issues:
+## WSL2: The Two-Computer Model
+
+WSL2 is where most HTTPS trust problems originate, so it's worth understanding what's actually happening.
+
+When you use DDEV on WSL2, you're working with two separate environments:
+
+- **Linux (WSL2)**: where DDEV runs, Docker runs, and your project files live
+- **Windows**: where your browser runs (Chrome, Edge, Firefox)
+
+These two environments do **not** share a certificate trust store. The Linux side and the Windows side each have their own. When your Windows browser visits `https://myproject.ddev.site`, it checks the **Windows** certificate store — it has no knowledge of anything installed on the Linux side.
+
+This means `mkcert -install` run inside WSL2 only installs the CA into the Linux trust store. Your Windows browser never sees it, and you get certificate warnings.
+
+:::tip[The DDEV Windows installer handles all of this]
+The normal way to set up DDEV on WSL2 is to run the [DDEV Windows installer](https://ddev.com/get-started/). It performs every step below automatically, and can be run again at any time to repair a broken configuration. The manual steps that follow are for understanding what the installer does, or for recovering from an unusual situation.
+:::
+
+### The Correct WSL2 Setup
+
+The solution is to keep the mkcert CA on the **Windows** filesystem and share it into WSL2:
+
+1. **Install mkcert on Windows** and run `mkcert -install` from PowerShell (not from WSL2). This puts the CA into the Windows certificate store where Chrome and Edge can find it.
+
+2. **Set `CAROOT` and `WSLENV`** so WSL2 uses the Windows CA instead of creating its own. From PowerShell:
+
+   ```powershell
+   $env:CAROOT = mkcert -CAROOT
+   setx CAROOT $env:CAROOT
+   $env:WSLENV = "CAROOT/up:$env:WSLENV"
+   setx WSLENV $env:WSLENV
+   ```
+
+   The `CAROOT/up` flag in `WSLENV` tells WSL2 to inherit the `CAROOT` variable from Windows and translate the path (e.g., `C:\Users\you\AppData\Local\mkcert` becomes `/mnt/c/Users/you/AppData/Local/mkcert`).
+
+3. **Restart WSL2** so the environment variable takes effect:
+
+   ```powershell
+   wsl --shutdown
+   ```
+
+4. **Verify** inside WSL2:
+
+   ```bash
+   echo $CAROOT
+   # Should show something like /mnt/c/Users/you/AppData/Local/mkcert
+   ```
+
+5. **Run `mkcert -install` inside WSL2** to register the Windows CA with the Linux system trust store as well (needed for `curl` and other Linux tools).
+
+6. **Restart DDEV**: `ddev poweroff && ddev start`
+
+### Exception: Browser Running Inside WSL2 via WSLg
+
+A small number of WSL2 users run their browser **inside** WSL2 using [WSLg](https://github.com/microsoft/wslg) (the Linux GUI app support built into modern Windows). If your browser is launched from inside the WSL2 terminal rather than from the Windows Start menu or taskbar, you're in this category.
+
+In that case, the browser is a Linux process and uses the Linux trust store — the Windows certificate store is irrelevant. The setup is the same as on a regular Linux machine: run `mkcert -install` inside WSL2 and you're done. The `CAROOT`/`WSLENV` setup described above is not needed.
+
+This is uncommon. If you're not sure which case applies to you, you're almost certainly running a Windows browser.
+
+### Why `CAROOT` Must Point to the Windows Filesystem
+
+DDEV generates per-project certificates by calling `mkcert --cert-file ... hostname`. For those certificates to be trusted by Windows browsers, they must be signed by the CA that Windows trusts — which is the one installed on the Windows side.
+
+If `$CAROOT` points to a Linux path (e.g., `/root/.local/share/mkcert`), DDEV will sign certificates with a Linux-only CA. Your Windows browser will reject them.
+
+You can always check where `CAROOT` is pointing:
+
+```bash
+mkcert -CAROOT
+# Should start with /mnt/c/...
+```
+
+### Firefox on Windows
+
+Firefox on Windows is a special case. Unlike Chrome and Edge, Firefox does **not** use the Windows system certificate store. It maintains its own trust store, so even a correctly configured CAROOT won't automatically make Firefox trust DDEV certificates.
+
+To use DDEV with Firefox on Windows, you must manually import the CA:
+
+1. Find the CA file: it's `rootCA.pem` inside the directory shown by `mkcert -CAROOT` (translated to a Windows path, e.g., `C:\Users\you\AppData\Local\mkcert\rootCA.pem`)
+2. In Firefox: **Settings → Privacy & Security → View Certificates → Authorities tab → Import**
+3. Import `rootCA.pem` and check "Trust this CA to identify websites"
+
+Firefox Nightly, Developer Edition, and ESR each maintain a **separate** trust store from standard Firefox. If you use any of these, repeat the import for each one.
+
+### Diagnosing WSL2 Certificate Problems
+
+DDEV v1.25.2 and later include a built-in diagnostic tool that checks every part of the certificate trust chain:
+
+```bash
+ddev utility tls-diagnose
+```
+
+It checks:
+
+- `mkcert` installation and `CAROOT` path
+- Whether `CAROOT` points to the Windows filesystem
+- Whether `WSLENV` is configured correctly
+- Whether the mkcert CA is in the Windows certificate store
+- Whether your project certificates are valid and signed by the current CA
+- Whether Chrome/Edge would actually trust a live HTTPS request (via PowerShell `Invoke-WebRequest`)
+
+Run this first when something isn't working.
+
+## Troubleshooting
 
 ### Browsers Still Show Warnings
 
 Some browsers don't automatically pick up the system trust store. Firefox, in particular, maintains its own certificate store. Run `mkcert -install` which should handle Firefox, but if issues persist, see the [browser configuration documentation](https://docs.ddev.com/en/stable/users/install/configuring-browsers/).
+
+**WSL2 users**: run `ddev utility tls-diagnose` — it will tell you exactly what's wrong and how to fix it.
 
 ### cURL Doesn't Trust Certificates
 
@@ -91,6 +198,22 @@ The `curl` inside DDEV's web container is already configured to trust DDEV certi
 ### Certificate Errors After System Updates
 
 Occasionally, OS updates can remove trusted CAs. If you start seeing certificate warnings after an update, run `mkcert -install` again to reinstall the local CA.
+
+### Nuclear Option
+
+When something is deeply broken — wrong CA, mismatched certificates, or an unknown state — start fresh:
+
+```bash
+ddev poweroff
+mkcert -uninstall
+rm -rf "$(mkcert -CAROOT)"
+mkcert -install
+ddev start
+```
+
+:::warning[WSL2 users]
+Run `mkcert -install` from Windows PowerShell (to update the Windows certificate store) **and** from inside WSL2 (to update the Linux trust store). Then restart DDEV.
+:::
 
 ### Manual Certificate Installation
 


### PR DESCRIPTION
## Summary

- Adds a WSL2-specific section to the [DDEV Trusted HTTPS Certificates](https://ddev.com/blog/ddev-local-trusted-https-certificates/) blog post explaining the "two-computer model" (Windows browser + Linux DDEV) and why a plain `mkcert -install` inside WSL2 is not enough for Windows browsers
- Covers `CAROOT`/`WSLENV` propagation, the WSLg browser exception, Firefox variant trust store caveats, and `ddev utility tls-diagnose` (v1.25.2+) as the first diagnostic step
- Prominently notes that the DDEV Windows installer handles all of this automatically and can be rerun to repair a broken configuration

Companion to ddev/ddev#8259 which adds `ddev utility tls-diagnose`.

## Test plan

Rendered critical content at https://pr-591.ddev-com-fork-previews.pages.dev/blog/ddev-local-trusted-https-certificates/#wsl2-the-two-computer-model (and probably throughout the article)

- [ ] Preview build renders the new WSL2 section correctly
- [ ] Callout boxes render (tip, warning)
- [ ] Internal link to `ddev-name-resolution-wildcards.md` resolves
- [ ] External links (WSLg, mkcert, DDEV docs) are correct

🤖 Generated with [Claude Code](https://claude.ai/code)