### PR TITLE
fix: normalize hyphenated search terms, fixes #602

### DIFF
--- a/src/lib/search-index.js
+++ b/src/lib/search-index.js
@@ -118,7 +118,13 @@ export default function searchIndex(config) {
 
         // Generate the index in the format we need
         let index = await getSearchIndex(items, {
+          fields: ["title", "heading", "text"],
           storeFields: ["title", "heading", "pubDate", "modifiedDate"],
+          // Keep hyphenated words as single tokens, then strip the hyphen so
+          // "add-on" and "addon" both resolve to the same indexed term.
+          tokenize: (string) =>
+            string.match(/[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*/g) || [],
+          processTerm: (term) => term.toLowerCase().replace(/-/g, ""),
         })
 
         // Write the index contents to a file

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -23,7 +23,13 @@ const title = `Search`
   const response = await fetch(indexPath)
   const searchData = await response.json()
   const searchIndex = loadIndex(searchData, {
+    fields: ["title", "heading", "text"],
     storeFields: ["title", "heading", "pubDate", "modifiedDate"],
+    // Keep hyphenated words as single tokens, then strip the hyphen so
+    // "add-on" and "addon" both resolve to the same indexed term.
+    tokenize: (string: string) =>
+      string.match(/[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*/g) || [],
+    processTerm: (term: string) => term.toLowerCase().replace(/-/g, ""),
   })
 
   let selectedResultIndex: number = -1


### PR DESCRIPTION
## The Issue

Searching for "add-on" did not match content containing "addon" (and vice versa), because MiniSearch treated them as distinct tokens.

- Fixes #602

## How This PR Solves The Issue

Configure MiniSearch `tokenize` and `processTerm` options in both the index builder (`src/lib/search-index.js`) and the search page (`src/pages/search.astro`) to keep hyphenated words as single tokens and strip hyphens before indexing/querying, so "add-on" and "addon" resolve to the same term.

## Manual Testing Instructions

Run search https://pr-607.ddev-com-fork-previews.pages.dev/search/