### PR TITLE
feat: add PhotoSwipe lightbox for blog post images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "mdast-util-to-string": "^4.0.0",
         "nanoid": "^5.0.1",
         "octokit": "^5.0.5",
+        "photoswipe": "^5.4.4",
         "postcss-import": "^16.1.1",
         "postcss-nested": "^7.0.2",
         "react": "^19.2.4",
@@ -10538,6 +10539,15 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/photoswipe": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
+      "integrity": "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.12.0"
+      }
     },
     "node_modules/piccolore": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mdast-util-to-string": "^4.0.0",
     "nanoid": "^5.0.1",
     "octokit": "^5.0.5",
+    "photoswipe": "^5.4.4",
     "postcss-import": "^16.1.1",
     "postcss-nested": "^7.0.2",
     "react": "^19.2.4",

--- a/src/components/FeatureImage.astro
+++ b/src/components/FeatureImage.astro
@@ -23,9 +23,18 @@ const resolveImage = async (path: string) => {
 }
 const resolvedSrc = await resolveImage(src)
 const resolvedSrcDark = srcDark ? await resolveImage(srcDark) : null
+
+function imgProps(resolved: ImageMetadata | string) {
+  if (typeof resolved !== 'object') return { pswpWidth: 1200, pswpHeight: 800, displayHeight: 500 }
+  const { width, height } = resolved
+  return { pswpWidth: width, pswpHeight: height, displayHeight: Math.round((900 * height) / width) }
+}
+
+const light = imgProps(resolvedSrc)
+const dark = resolvedSrcDark ? imgProps(resolvedSrcDark) : null
 ---
 
-<figure class={`w-full mx-auto mb-24 z-10 px-6 lg:px-0`}>
+<figure class={`pswp-feature w-full mx-auto mb-24 z-10 px-6 lg:px-0`}>
   {
     src.includes(".svg") ? (
       <>
@@ -34,25 +43,37 @@ const resolvedSrcDark = srcDark ? await resolveImage(srcDark) : null
       </>
     ) : (
       <>
-        <div class={`block rounded-lg overflow-hidden${shadow ? " shadow-xl" : ""}${resolvedSrcDark ? " dark:hidden" : ""}`}>
+        <a
+          href={src}
+          data-pswp-src={src}
+          data-pswp-width={String(light.pswpWidth)}
+          data-pswp-height={String(light.pswpHeight)}
+          class={`block rounded-lg overflow-hidden cursor-zoom-in${shadow ? " shadow-xl" : ""}${dark ? " dark:hidden" : ""}`}
+        >
           <Picture
             class="block w-full h-auto rounded-lg"
             src={resolvedSrc as any}
             alt={alt}
             width={900}
-            height={500}
+            height={light.displayHeight}
           />
-        </div>
-        {resolvedSrcDark && (
-          <div class={`hidden dark:block rounded-lg overflow-hidden${shadow ? " shadow-xl" : ""}`}>
+        </a>
+        {dark && (
+          <a
+            href={srcDark}
+            data-pswp-src={srcDark}
+            data-pswp-width={String(dark.pswpWidth)}
+            data-pswp-height={String(dark.pswpHeight)}
+            class={`hidden dark:block rounded-lg overflow-hidden cursor-zoom-in${shadow ? " shadow-xl" : ""}`}
+          >
             <Picture
               class="block w-full h-auto rounded-lg"
               src={resolvedSrcDark as any}
               alt={alt}
               width={900}
-              height={500}
+              height={dark.displayHeight}
             />
-          </div>
+          </a>
         )}
       </>
     )

--- a/src/content/blog/markdown-features-demo.md
+++ b/src/content/blog/markdown-features-demo.md
@@ -346,13 +346,15 @@ Here's a workflow with embedded callouts:
 
 ## Images and Figures
 
-Images are automatically wrapped in semantic `<figure>` elements with captions generated from alt text:
-
-![Installation speed](/img/blog/2022/03/macos-m1-vs.-drupal-drush-install-seconds.png)
+Images are automatically wrapped in semantic `<figure>` elements with captions generated from alt text. Click any image to open it fullscreen.
 
 The alt text becomes the figure caption, improving both accessibility and visual presentation:
 
-![Weird installation graph](/img/blog/2022/03/macos-m1-vs.-drupal-drush-install-seconds.png)
+![macOS M1 vs x86 Drupal installation time in seconds](/img/blog/2022/03/macos-m1-vs.-drupal-drush-install-seconds.png)
+
+![DDEV 2025 roadmap and plans overview](/img/blog/2025/02/ddev-2025-plans.png)
+
+![DDEV add-on search demo animation](/img/blog/2025/03/ddev-addon-search.gif)
 
 :::tip[Image Best Practices]
 

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -147,4 +147,5 @@ const blogPostSchema = [
     </div>
   </main>
   <BlogPostFooter activeSlug={entry.id} />
+  <script src="/src/scripts/photoswipe-init.js"></script>
 </Layout>

--- a/src/scripts/photoswipe-init.js
+++ b/src/scripts/photoswipe-init.js
@@ -1,41 +1,31 @@
 import PhotoSwipeLightbox from "photoswipe/lightbox"
 import "photoswipe/dist/photoswipe.css"
 
-async function initPhotoSwipe() {
+function initPhotoSwipe() {
   const prose = document.querySelector(".prose")
-  if (!prose) return
+  if (prose) {
+    prose.querySelectorAll("img:not(a img):not(picture img)").forEach((img) => {
+      const width = img.naturalWidth || +img.getAttribute("width") || 1200
+      const height = img.naturalHeight || +img.getAttribute("height") || 800
+      const a = document.createElement("a")
+      a.href = img.src
+      a.className = "cursor-zoom-in"
+      a.dataset.pswpSrc = img.src
+      a.dataset.pswpWidth = String(width)
+      a.dataset.pswpHeight = String(height)
+      img.replaceWith(a)
+      a.appendChild(img)
+    })
+  }
 
-  const imgs = [...prose.querySelectorAll("img")].filter(
-    (img) => !img.closest("a") && !img.closest("picture")
-  )
-  if (!imgs.length) return
+  const galleries = document.querySelectorAll(".pswp-feature, .prose")
+  if (![...galleries].some((g) => g.querySelector("a[data-pswp-src]"))) return
 
-  await Promise.all(
-    imgs.map((img) =>
-      img.complete
-        ? Promise.resolve()
-        : new Promise((r) => {
-            img.onload = img.onerror = () => r()
-          })
-    )
-  )
-
-  imgs.forEach((img) => {
-    const a = document.createElement("a")
-    a.href = img.src
-    a.dataset.pswpSrc = img.src
-    a.dataset.pswpWidth = String(img.naturalWidth || 1200)
-    a.dataset.pswpHeight = String(img.naturalHeight || 800)
-    img.parentNode.insertBefore(a, img)
-    a.appendChild(img)
-  })
-
-  const lightbox = new PhotoSwipeLightbox({
-    gallery: ".prose",
+  new PhotoSwipeLightbox({
+    gallery: galleries,
     children: "a[data-pswp-src]",
     pswpModule: () => import("photoswipe"),
-  })
-  lightbox.init()
+  }).init()
 }
 
 initPhotoSwipe()

--- a/src/scripts/photoswipe-init.js
+++ b/src/scripts/photoswipe-init.js
@@ -1,0 +1,41 @@
+import PhotoSwipeLightbox from "photoswipe/lightbox"
+import "photoswipe/dist/photoswipe.css"
+
+async function initPhotoSwipe() {
+  const prose = document.querySelector(".prose")
+  if (!prose) return
+
+  const imgs = [...prose.querySelectorAll("img")].filter(
+    (img) => !img.closest("a") && !img.closest("picture")
+  )
+  if (!imgs.length) return
+
+  await Promise.all(
+    imgs.map((img) =>
+      img.complete
+        ? Promise.resolve()
+        : new Promise((r) => {
+            img.onload = img.onerror = () => r()
+          })
+    )
+  )
+
+  imgs.forEach((img) => {
+    const a = document.createElement("a")
+    a.href = img.src
+    a.dataset.pswpSrc = img.src
+    a.dataset.pswpWidth = String(img.naturalWidth || 1200)
+    a.dataset.pswpHeight = String(img.naturalHeight || 800)
+    img.parentNode.insertBefore(a, img)
+    a.appendChild(img)
+  })
+
+  const lightbox = new PhotoSwipeLightbox({
+    gallery: ".prose",
+    children: "a[data-pswp-src]",
+    pswpModule: () => import("photoswipe"),
+  })
+  lightbox.init()
+}
+
+initPhotoSwipe()

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,6 +54,10 @@ img {
   @apply font-mono text-sm text-gray-500;
 }
 
+.prose figure img {
+  cursor: zoom-in;
+}
+
 .footnotes {
   @apply border-t mt-24 pt-4 text-base;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,10 +54,6 @@ img {
   @apply font-mono text-sm text-gray-500;
 }
 
-.prose figure img {
-  cursor: zoom-in;
-}
-
 .footnotes {
   @apply border-t mt-24 pt-4 text-base;
 }


### PR DESCRIPTION
## The Issue

Blog post images were not clickable or viewable fullscreen.

## How This PR Solves The Issue

- Adds [PhotoSwipe v5](https://github.com/dimsemenov/photoswipe) (MIT) lightbox to blog posts
- Images in `.prose` are wrapped in PhotoSwipe anchors at runtime
- Feature image opens in its original format (PNG/JPG/GIF), useful for high-quality artwork                                                         
- Feature image dimensions are computed from metadata instead of hardcoded 900×500 
- Supports keyboard navigation and mobile swipe/pinch-to-zoom

## Manual Testing Instructions

- Open https://pr-616.ddev-com-fork-previews.pages.dev/blog/markdown-features-demo/#images-and-figures
- Hover an image - cursor should show zoom icon
- Click an image - lightbox opens fullscreen
- Navigate with arrow keys or swipe on mobile
- Close with Escape or click outside
- Open https://pr-616.ddev-com-fork-previews.pages.dev/blog/ddev-jan-2026-newsletter/ - click the feature image to see original format

🤖 Developed with assistance from [Claude Code](https://claude.ai/code)