### PR TITLE
docs(windows): update instructions to use Ubuntu-24.04

### DIFF
--- a/src/components/quickstart/Windows.astro
+++ b/src/components/quickstart/Windows.astro
@@ -32,7 +32,7 @@ const { latestVersion } = Astro.props
 
   <p>Run the following in PowerShell terminal:</p>
 
-  <Terminal type="powershell" code={`> wsl --install`} />
+  <Terminal type="powershell" code={`> wsl --install --no-distribution`} />
 
   <p>You’ll probably need to reboot.</p>
 
@@ -42,7 +42,7 @@ const { latestVersion } = Astro.props
   
   <p>Then, install an Ubuntu distro named "DDEV":</p>
 
-  <Terminal type="powershell" code={`> wsl --install Ubuntu --name DDEV`} />
+  <Terminal type="powershell" code={`> wsl --install Ubuntu-24.04 --name DDEV`} />
   
   <p>Verify that you now have an Ubuntu distro set as default:</p>
 


### PR DESCRIPTION
## The Issue

Sync with https://docs.ddev.com/en/stable/users/install/ddev-installation/#ddev-installation-windows

- https://github.com/ddev/ddev/issues/8326

## How This PR Solves The Issue

Updates the instructions.

## Manual Testing Instructions

Windows https://pr-636.ddev-com-fork-previews.pages.dev/get-started/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

