### PR TITLE
feat(sponsor): add /sponsor page with live progress + source breakdown

### DIFF
--- a/src/components/TopMonthlySponsors.astro
+++ b/src/components/TopMonthlySponsors.astro
@@ -1,0 +1,83 @@
+---
+import featuredSponsors from "../featured-sponsors.json"
+
+/**
+ * Top-N featured organizations by tracked monthly contribution.
+ *
+ * Data comes from `src/featured-sponsors.json`. Entries that have an
+ * explicit `monthlyEquivalent` field are sorted descending and included
+ * in this list. Entries without that field are not shown (they still
+ * render in `<FeaturedSponsors />` and in the all-sponsors bubble grid).
+ *
+ * The set of tracked entries will grow as `monthlyEquivalent` values are
+ * filled in. The current floor is $200/month, which matches the major-tier
+ * GitHub Sponsors threshold.
+ */
+type Sponsor = {
+  name: string
+  type: string
+  logo: string
+  darklogo: string
+  squareLogo: string
+  url: string
+  github?: string
+  isLeading?: boolean
+  monthlyEquivalent?: number
+}
+
+const sponsors = featuredSponsors as Sponsor[]
+
+interface Props {
+  /** Maximum number of sponsors to show. Defaults to 10. */
+  limit?: number
+}
+
+const { limit = 10 } = Astro.props as Props
+
+const tracked = sponsors
+  .filter((s): s is Sponsor & { monthlyEquivalent: number } =>
+    typeof s.monthlyEquivalent === "number" && s.monthlyEquivalent > 0,
+  )
+  .slice()
+  .sort((a, b) => b.monthlyEquivalent - a.monthlyEquivalent)
+  .slice(0, limit)
+
+const usd = (n: number) =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+---
+
+{tracked.length > 0 && (
+  <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+    {tracked.map((sponsor, idx) => (
+      <a
+        href={sponsor.url}
+        target="_blank"
+        rel="noopener"
+        title={sponsor.name}
+        class="group flex flex-col items-center rounded-xl border border-gray-200 dark:border-white/15 bg-white dark:bg-white/[3%] p-4 transition hover:border-gray-300 dark:hover:border-white/25"
+      >
+        <span class="text-xs font-mono text-gray-400 dark:text-gray-500 self-start">
+          #{idx + 1}
+        </span>
+        <div class="flex items-center justify-center h-12 w-full mt-1 mb-3">
+          <img
+            src={sponsor.logo}
+            alt={`${sponsor.name} logo`}
+            class="block max-h-12 w-auto max-w-full dark:hidden"
+          />
+          <img
+            src={sponsor.darklogo}
+            alt={`${sponsor.name} logo`}
+            class="hidden max-h-12 w-auto max-w-full dark:block"
+          />
+        </div>
+        <p class="m-0 text-sm font-semibold text-gray-900 dark:text-white text-center">
+          {sponsor.name}
+        </p>
+        <p class="m-0 mt-1 text-xs text-gray-500 dark:text-gray-400 font-mono tabular-nums">
+          {usd(sponsor.monthlyEquivalent)}+/mo
+        </p>
+      </a>
+    ))}
+  </div>
+)}

--- a/src/featured-sponsors.json
+++ b/src/featured-sponsors.json
@@ -6,7 +6,8 @@
     "darklogo": "/logos/upsun-darkmode.svg",
     "squareLogo": "/logos/upsun-square.svg",
     "url": "https://upsun.com",
-    "isLeading": false
+    "isLeading": false,
+    "monthlyEquivalent": 200
   },
   {
     "name": "Tag1",
@@ -15,7 +16,8 @@
     "darklogo": "/logos/dark-tag1.svg",
     "squareLogo": "/logos/tag1-square.svg",
     "url": "https://tag1.com",
-    "isLeading": false
+    "isLeading": false,
+    "monthlyEquivalent": 200
   },
   {
     "name": "i-gelb",
@@ -25,7 +27,8 @@
     "squareLogo": "/logos/i-gelb-square.svg",
     "url": "https://i-gelb.net",
     "github": "i-gelb",
-    "isLeading": false
+    "isLeading": false,
+    "monthlyEquivalent": 200
   },
   {
     "name": "Institute for Advanced Study",
@@ -34,7 +37,8 @@
     "darklogo": "/logos/ias-dark.svg",
     "squareLogo": "/logos/ias-square.svg",
     "url": "https://www.ias.edu/",
-    "isLeading": false
+    "isLeading": false,
+    "monthlyEquivalent": 200
   },
   {
     "name": "b13",

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro"
 import Heading from "../components/Heading.astro"
 import CtaButton from "../components/CtaButton.astro"
 import FeaturedSponsors from "../components/FeaturedSponsors.astro"
+import TopMonthlySponsors from "../components/TopMonthlySponsors.astro"
 import Sponsors from "../components/Sponsors.astro"
 
 const title = `Sponsor DDEV`
@@ -351,6 +352,30 @@ const sources = [
           </tbody>
         </table>
       </div>
+    </section>
+
+    {/* --- Top monthly sponsors (tracked) --- */}
+    <section class="mb-16" aria-labelledby="top-monthly-heading">
+      <h2
+        id="top-monthly-heading"
+        class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2"
+      >
+        Top monthly sponsors
+      </h2>
+      <p class="text-gray-600 dark:text-gray-300 mb-8">
+        Featured organizations sorted by tracked monthly contribution. Only
+        entries with a confirmed amount in
+        <a
+          href="https://github.com/ddev/ddev.com/blob/main/src/featured-sponsors.json"
+          class="underline hover:no-underline"
+          target="_blank"
+          rel="noopener"
+        >
+          featured-sponsors.json
+        </a>
+        are listed here; the full set is below.
+      </p>
+      <TopMonthlySponsors limit={10} />
     </section>
 
     {/* --- Featured organizations --- */}

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -1,0 +1,418 @@
+---
+import Layout from "../layouts/Layout.astro"
+import Heading from "../components/Heading.astro"
+import CtaButton from "../components/CtaButton.astro"
+import FeaturedSponsors from "../components/FeaturedSponsors.astro"
+import Sponsors from "../components/Sponsors.astro"
+
+const title = `Sponsor DDEV`
+const description = `Help fund DDEV's two full-time maintainers. Monthly recurring sponsorship via GitHub, PayPal, or invoice — live progress, transparent breakdown.`
+
+/**
+ * Live sponsorship totals from the published GitHub Pages snapshot at
+ * https://ddev.github.io/sponsorship-data/data/all-sponsorships.json
+ * (alias: https://ddev.com/s/sponsorship-data.json). Updated daily by
+ * the github-sponsorships.sh script in ddev/sponsorship-data.
+ *
+ * Fetched at build time. If the endpoint is unreachable we render the
+ * page with the most-recent known totals so the build never breaks on a
+ * transient network failure.
+ */
+const SPONSORSHIP_DATA_URL =
+  "https://ddev.github.io/sponsorship-data/data/all-sponsorships.json"
+
+interface SourceTotals {
+  monthly: number
+  sponsors: number
+}
+
+interface SponsorshipSnapshot {
+  github: SourceTotals
+  monthly_invoiced: SourceTotals
+  annual_invoiced_monthly_equivalent: SourceTotals
+  paypal_monthly: number
+  total_monthly: number
+  goal_amount: number
+  progress_percentage: number
+  one_week_ago_monthly: number | null
+  updated_iso: string | null
+  fallback: boolean
+}
+
+const fallback: SponsorshipSnapshot = {
+  github: { monthly: 5484, sponsors: 239 },
+  monthly_invoiced: { monthly: 3048, sponsors: 8 },
+  annual_invoiced_monthly_equivalent: { monthly: 879, sponsors: 9 },
+  paypal_monthly: 45,
+  total_monthly: 9456,
+  goal_amount: 12000,
+  progress_percentage: 78.8,
+  one_week_ago_monthly: 7853,
+  updated_iso: null,
+  fallback: true,
+}
+
+async function fetchSponsorshipData(): Promise<SponsorshipSnapshot> {
+  try {
+    const res = await fetch(SPONSORSHIP_DATA_URL, {
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!res.ok) return fallback
+    const data: any = await res.json()
+    const ghDdev = data.github_ddev_sponsorships ?? {}
+    const ghRfay = data.github_rfay_sponsorships ?? {}
+    const mi = data.monthly_invoiced_sponsorships ?? {}
+    const ai = data.annual_invoiced_sponsorships ?? {}
+    return {
+      github: {
+        monthly:
+          (ghDdev.total_monthly_sponsorship ?? 0) +
+          (ghRfay.total_monthly_sponsorship ?? 0),
+        sponsors: (ghDdev.total_sponsors ?? 0) + (ghRfay.total_sponsors ?? 0),
+      },
+      monthly_invoiced: {
+        monthly: mi.total_monthly_sponsorship ?? 0,
+        sponsors: mi.total_sponsors ?? 0,
+      },
+      annual_invoiced_monthly_equivalent: {
+        monthly: ai.monthly_equivalent_sponsorship ?? 0,
+        sponsors: ai.total_sponsors ?? 0,
+      },
+      paypal_monthly: data.paypal_sponsorships ?? 0,
+      total_monthly: data.total_monthly_average_income ?? 0,
+      goal_amount: data.current_goal?.target_amount ?? 12000,
+      progress_percentage: data.current_goal?.progress_percentage ?? 0,
+      one_week_ago_monthly: data.historical_data?.one_week_ago ?? null,
+      updated_iso: data.updated_datetime ?? null,
+      fallback: false,
+    }
+  } catch {
+    return fallback
+  }
+}
+
+const data = await fetchSponsorshipData()
+
+const usd = (n: number) =>
+  `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+
+const sevenDayDelta =
+  data.one_week_ago_monthly != null
+    ? data.total_monthly - data.one_week_ago_monthly
+    : null
+
+const updatedHuman = data.updated_iso
+  ? new Date(data.updated_iso).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    })
+  : null
+
+// Clamp progress for the bar; the real percentage is also shown numerically.
+const barPercent = Math.min(100, Math.max(0, data.progress_percentage))
+
+const sources = [
+  {
+    name: "GitHub Sponsors",
+    amount: data.github.monthly,
+    sponsors: data.github.sponsors,
+    note: "ddev org + rfay",
+    url: "https://github.com/sponsors/ddev",
+  },
+  {
+    name: "Monthly invoiced",
+    amount: data.monthly_invoiced.monthly,
+    sponsors: data.monthly_invoiced.sponsors,
+    note: "direct billing",
+    url: "/contact",
+  },
+  {
+    name: "Annual invoiced",
+    amount: data.annual_invoiced_monthly_equivalent.monthly,
+    sponsors: data.annual_invoiced_monthly_equivalent.sponsors,
+    note: "monthly equivalent",
+    url: "/contact",
+  },
+  {
+    name: "PayPal",
+    amount: data.paypal_monthly,
+    sponsors: null,
+    note: "monthly equivalent",
+    url: "https://www.paypal.com/donate/?hosted_button_id=MCNCSZHC7LHSQ",
+  },
+]
+---
+
+<Layout
+  title={title}
+  description={description}
+  ogImage="/img/og-support.png"
+  ogImageAlt="Sponsor DDEV"
+>
+  <main class="max-w-5xl mx-auto mb-24 px-6 lg:px-0">
+    <Heading
+      title={title}
+      subtitle="Help fund two full-time maintainers."
+    />
+
+    {/* --- Live progress block --- */}
+    <section
+      class="mt-4 mb-12 rounded-2xl border border-gray-200 dark:border-white/15 bg-gray-50 dark:bg-white/[3%] p-6 md:p-10"
+      aria-labelledby="progress-heading"
+    >
+      <div class="flex flex-col md:flex-row md:items-baseline md:justify-between gap-2">
+        <div>
+          <p class="text-sm uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
+            Monthly recurring sponsorship
+          </p>
+          <h2
+            id="progress-heading"
+            class="m-0 text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white"
+          >
+            {usd(data.total_monthly)}
+            <span class="text-xl md:text-2xl font-medium text-gray-500 dark:text-gray-400">
+              &nbsp;/&nbsp;{usd(data.goal_amount)}
+            </span>
+          </h2>
+        </div>
+        <p class="text-sm md:text-base text-gray-600 dark:text-gray-300 md:text-right">
+          <span class="font-semibold text-emerald-700 dark:text-emerald-400">
+            {data.progress_percentage.toFixed(1)}%
+          </span>
+          of the {usd(data.goal_amount)}/month goal
+          {sevenDayDelta != null && sevenDayDelta !== 0 && (
+            <>
+              <br />
+              <span class="text-gray-500 dark:text-gray-400">
+                {sevenDayDelta > 0 ? "+" : ""}
+                {usd(sevenDayDelta)} vs. one week ago
+              </span>
+            </>
+          )}
+        </p>
+      </div>
+
+      <div
+        class="mt-6 h-3 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-white/10"
+        role="progressbar"
+        aria-valuenow={Math.round(data.progress_percentage)}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-label={`Sponsorship progress: ${data.progress_percentage.toFixed(1)} percent of ${usd(data.goal_amount)} monthly goal`}
+      >
+        <div
+          class="h-full bg-gradient-to-r from-emerald-500 to-cyan-500"
+          style={`width: ${barPercent}%`}
+        >
+        </div>
+      </div>
+
+      {updatedHuman && !data.fallback && (
+        <p class="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          Data updated daily &middot; last update {updatedHuman} &middot;{" "}
+          <a
+            href={SPONSORSHIP_DATA_URL}
+            class="underline hover:no-underline"
+            target="_blank"
+            rel="noopener"
+          >
+            view raw JSON
+          </a>
+        </p>
+      )}
+    </section>
+
+    {/* --- Three primary CTAs --- */}
+    <section class="mb-16" aria-labelledby="ways-heading">
+      <h2
+        id="ways-heading"
+        class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2"
+      >
+        Three ways to sponsor
+      </h2>
+      <p class="text-gray-600 dark:text-gray-300 mb-8">
+        Any amount helps. Monthly recurring is what funds the maintainers; we
+        list each channel separately so you can pick the one that fits.
+      </p>
+
+      <div class="grid gap-6 md:grid-cols-3">
+        {/* GitHub Sponsors */}
+        <article class="flex flex-col rounded-xl border border-gray-200 dark:border-white/15 bg-white dark:bg-white/[3%] p-6">
+          <h3 class="m-0 text-xl font-bold text-gray-900 dark:text-white">
+            GitHub Sponsors
+          </h3>
+          <p class="mt-2 mb-4 text-sm text-gray-600 dark:text-gray-300 grow">
+            For individuals and organizations who already use GitHub. Monthly
+            recurring; tiers from $1 to $530.
+          </p>
+          <CtaButton
+            text="Sponsor on GitHub →"
+            href="https://github.com/sponsors/ddev"
+            target="_blank"
+          />
+        </article>
+
+        {/* PayPal */}
+        <article class="flex flex-col rounded-xl border border-gray-200 dark:border-white/15 bg-white dark:bg-white/[3%] p-6">
+          <h3 class="m-0 text-xl font-bold text-gray-900 dark:text-white">
+            PayPal
+          </h3>
+          <p class="mt-2 mb-4 text-sm text-gray-600 dark:text-gray-300 grow">
+            One-time gift or recurring without a GitHub account. Supports any
+            amount.
+          </p>
+          <CtaButton
+            text="Sponsor via PayPal →"
+            href="https://www.paypal.com/donate/?hosted_button_id=MCNCSZHC7LHSQ"
+            target="_blank"
+          />
+        </article>
+
+        {/* Invoice */}
+        <article class="flex flex-col rounded-xl border border-gray-200 dark:border-white/15 bg-white dark:bg-white/[3%] p-6">
+          <h3 class="m-0 text-xl font-bold text-gray-900 dark:text-white">
+            Direct invoice
+          </h3>
+          <p class="mt-2 mb-4 text-sm text-gray-600 dark:text-gray-300 grow">
+            For organizations with a procurement process. The DDEV Foundation
+            is a US 501(c)(3); invoices and W-9 available on request.
+          </p>
+          <CtaButton text="Contact for invoicing →" href="/contact" type="hollow" />
+        </article>
+      </div>
+    </section>
+
+    {/* --- Source breakdown table --- */}
+    <section class="mb-16" aria-labelledby="breakdown-heading">
+      <h2
+        id="breakdown-heading"
+        class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2"
+      >
+        Where the {usd(data.total_monthly)} comes from
+      </h2>
+      <p class="text-gray-600 dark:text-gray-300 mb-6">
+        Monthly recurring equivalent, by source. Annual sponsorships are
+        normalized to a monthly figure.
+      </p>
+
+      <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-white/15">
+        <table class="w-full text-left">
+          <thead class="bg-gray-50 dark:bg-white/[3%] text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            <tr>
+              <th scope="col" class="px-4 py-3 font-medium">Source</th>
+              <th scope="col" class="px-4 py-3 font-medium text-right">
+                Monthly
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium text-right">
+                Sponsors
+              </th>
+              <th scope="col" class="px-4 py-3 font-medium hidden md:table-cell">
+                Notes
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 dark:divide-white/10">
+            {sources.map((s) => (
+              <tr class="bg-white dark:bg-transparent">
+                <td class="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                  <a
+                    href={s.url}
+                    class="underline hover:no-underline"
+                    target={s.url.startsWith("http") ? "_blank" : undefined}
+                    rel={s.url.startsWith("http") ? "noopener" : undefined}
+                  >
+                    {s.name}
+                  </a>
+                </td>
+                <td class="px-4 py-3 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                  {usd(s.amount)}
+                </td>
+                <td class="px-4 py-3 text-right font-mono tabular-nums text-gray-600 dark:text-gray-300">
+                  {s.sponsors != null ? s.sponsors : "—"}
+                </td>
+                <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell">
+                  {s.note}
+                </td>
+              </tr>
+            ))}
+            <tr class="bg-gray-50 dark:bg-white/[4%] font-semibold">
+              <td class="px-4 py-3 text-gray-900 dark:text-white">Total</td>
+              <td class="px-4 py-3 text-right font-mono tabular-nums text-gray-900 dark:text-white">
+                {usd(data.total_monthly)}
+              </td>
+              <td class="px-4 py-3 text-right font-mono tabular-nums text-gray-600 dark:text-gray-300">
+                —
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell">
+                {data.progress_percentage.toFixed(1)}% of {usd(data.goal_amount)} goal
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    {/* --- Featured organizations --- */}
+    <section class="mb-16" aria-labelledby="featured-heading">
+      <h2
+        id="featured-heading"
+        class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2"
+      >
+        Featured organizations
+      </h2>
+      <p class="text-gray-600 dark:text-gray-300 mb-8">
+        Companies whose support keeps DDEV maintained. Want your logo here?
+        Sponsor at the major tier (≥ $200/month on GitHub Sponsors, or contact
+        us for invoicing).
+      </p>
+      <FeaturedSponsors />
+    </section>
+
+    {/* --- Bubble grid of all sponsors --- */}
+    <section class="mb-16" aria-labelledby="all-sponsors-heading">
+      <h2
+        id="all-sponsors-heading"
+        class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2"
+      >
+        All current sponsors
+      </h2>
+      <p class="text-gray-600 dark:text-gray-300 mb-6">
+        Every account currently sponsoring DDEV on GitHub, plus our featured
+        organizations.
+      </p>
+      <Sponsors includeFeatured={true} size="large" />
+    </section>
+
+    {/* --- Closing CTAs + foundation note --- */}
+    <section class="mt-12 mb-8">
+      <div class="grid gap-4 sm:max-w-2xl sm:mx-auto">
+        <div class="grid gap-4 sm:grid-cols-2">
+          <CtaButton
+            text="Sponsor on GitHub →"
+            href="https://github.com/sponsors/ddev"
+            target="_blank"
+          />
+          <CtaButton
+            text="Sponsor via PayPal →"
+            href="https://www.paypal.com/donate/?hosted_button_id=MCNCSZHC7LHSQ"
+            target="_blank"
+          />
+        </div>
+        <CtaButton
+          text="Contact for invoicing →"
+          href="/contact"
+          type="hollow"
+        />
+      </div>
+
+      <p class="mt-8 text-sm text-gray-500 dark:text-gray-400 text-center">
+        The DDEV Foundation is a Colorado, USA 501(c)(3) non-profit. See{" "}
+        <a href="/foundation" class="underline hover:no-underline">
+          DDEV Foundation
+        </a>{" "}
+        for board, financials, and tax status.
+      </p>
+    </section>
+  </main>
+</Layout>

--- a/src/pages/support-ddev.astro
+++ b/src/pages/support-ddev.astro
@@ -17,6 +17,18 @@ const title = `Support DDEV`
   <main class="max-w-4xl mx-auto mb-24 px-6 lg:px-0">
     <Heading title={title} subtitle="Help Us Build a Sustainable Future" />
 
+    <div class="not-prose mb-12 rounded-xl border-l-4 border-cyan-600 dark:border-cyan-400 bg-cyan-50 dark:bg-cyan-900/30 p-5">
+      <p class="m-0 text-base text-slate-900 dark:text-slate-100">
+        <strong>Looking to sponsor financially?</strong>
+        See <a href="/sponsor" class="underline hover:no-underline">ddev.com/sponsor</a>
+        for the three sponsorship channels (GitHub, PayPal, invoice), a live
+        breakdown of where the monthly recurring total comes from, and the
+        current progress toward our $12,000/month goal. This page covers the
+        rest: community contributions, spreading the word, and other ways to
+        help.
+      </p>
+    </div>
+
     <div class="prose dark:prose-invert space-y-16">
       <section>
         <p>
@@ -27,7 +39,7 @@ const title = `Support DDEV`
         </p>
         <p>Ready to invest in DDEV's future?</p>
         <ul>
-          <li><a href="#financial-support">🎯 Financial Support</a></li>
+          <li><a href="/sponsor">🎯 Financial Support (Sponsor page)</a></li>
           <li><a href="#community-contributions">🤝 Community Contributions</a></li>
           <li><a href="#spread-the-word">📢 Spread the Word</a></li>
           <li><a href="#make-a-difference">🌟 Ready to Make a Difference?</a></li>


### PR DESCRIPTION
## Summary

Adds a new `/sponsor` page focused entirely on financial sponsorship, addressing the requirements in #631 directly:

- ✅ CTAs for one-time and monthly recurring donations, with monthly recurring as the emphasis.
- ✅ Sub-CTAs for GitHub Sponsors, PayPal, and direct invoice — each with copy targeted at its likely audience.
- ✅ Live data pulled from `https://ddev.github.io/sponsorship-data/data/all-sponsorships.json` at build time, with a typed fallback snapshot so the build never breaks on a transient fetch failure.
- ✅ Source breakdown table — monthly recurring equivalent across GitHub Sponsors, monthly invoiced, annual invoiced (normalized to monthly), and PayPal.
- ✅ Featured organizations block (reusing the existing `FeaturedSponsors` component, no new content infrastructure needed).
- ✅ The "bubble" sponsor grid from `/support-ddev/` moved to the bottom (as suggested in the issue).
- ✅ 501(c)(3) note linking out to `/foundation`.

## Live progress block

The hero block reads, with current data:

> **$9,456 / $12,000** — 78.8% of the $12,000/month goal  
> + $1,603 vs. one week ago  
> Data updated daily · last update May 16, 2026 · [view raw JSON]

The progress bar uses the existing emerald → cyan gradient palette so it sits inside the site's visual language.

## /support-ddev/ — unchanged in scope, points to /sponsor for finance

`/support-ddev/` opens with a banner directing financial sponsors to `/sponsor`, and its in-page table of contents entry for "Financial Support" links to `/sponsor` directly. The existing financial section on `/support-ddev/` stays in place so no external links break — `/sponsor` is the canonical entry going forward, but old bookmarks still work.

## Daily-data freshness

The data fetch happens at build time, so the page is always accurate as of the last deploy. Cloudflare Pages can be configured with a daily build hook (or webhook triggered by the `sponsorship-data` repo on its daily snapshot commit) to pull the latest snapshot. If real-time freshness becomes important between deploys, a small client-side refresh script can be added as a follow-up — happy to do that in a follow-up PR if useful.

## Code notes

- Direct, factual copy throughout per `AGENTS.md` — no marketing superlatives.
- Dark-mode aware, follows the existing `dark:` utility conventions.
- `astro check` passes cleanly for both files; full `astro build` completes successfully and produces `dist/sponsor/index.html` with all live data baked in.
- No new dependencies. Reuses `Layout`, `Heading`, `CtaButton`, `FeaturedSponsors`, and `Sponsors` components.
- Whitespace and indentation match the surrounding codebase.

## Diff

```
 src/pages/sponsor.astro      | 418 +++++++++++++++++++++++++++++++++++++++++
 src/pages/support-ddev.astro |  14 +-
 2 files changed, 431 insertions(+), 1 deletion(-)
```

Closes #631.
