### PR TITLE
chore: remove Optasy from featured sponsors

### DIFF
--- a/src/featured-sponsors.json
+++ b/src/featured-sponsors.json
@@ -100,15 +100,6 @@
     "github": "mobilistics"
   },
   {
-    "name": "optasy",
-    "type": "standard",
-    "logo": "/logos/optasy-full.svg",
-    "darklogo": "/logos/optasy-darkmode.svg",
-    "squareLogo": "/logos/optasy-square.svg",
-    "url": "https://www.optasy.com/",
-    "github": "OPTASY"
-  },
-  {
     "name": "Redfin Solutions",
     "type": "standard",
     "logo": "/logos/redfin-solutions.svg",


### PR DESCRIPTION
Optasy has stopped supporting DDEV.


Remove from featured sponsors.

Review at https://pr-651.ddev-com-fork-previews.pages.dev/

I left the svg files there in case they come back.