### PR TITLE
blog(vite): clarify DDEV_PRIMARY_URL_WITHOUT_PORT

### DIFF
--- a/src/content/blog/working-with-vite-in-ddev.md
+++ b/src/content/blog/working-with-vite-in-ddev.md
@@ -1,7 +1,7 @@
 ---
 title: "Working with Vite in DDEV - an introduction"
 pubDate: 2023-11-08
-modifiedDate: 2025-10-27
+modifiedDate: 2026-07-21
 modifiedComment: "Added a link to the [official DDEV Vite Integration documentation](https://docs.ddev.com/en/stable/users/usage/vite/)."
 summary: Working with Vite in DDEV
 author: Matthias Andrasch
@@ -193,6 +193,10 @@ export default defineConfig({
 })
 ```
 
+:::note
+The [`DDEV_PRIMARY_URL_WITHOUT_PORT`](https://docs.ddev.com/en/stable/users/extend/custom-commands/#environment-variables-provided) environment variable requires DDEV v1.24.5 or later. We recommend keeping DDEV updated to the [latest stable release](/download/).
+:::
+
 Technical explanation:
 
 - We need to define an entry file to let vite know where to start, this is done in `rollupOptions`.
@@ -255,8 +259,8 @@ And we will need a simple PHP index file of course. We put it in the root folder
     <title>Hello Vite!</title>
 
     <!-- This is just an example for local development, no full integration: -->
-    <script type="module" src="<?php echo preg_replace('/:\d+$/', '', $_SERVER['DDEV_PRIMARY_URL_WITHOUT_PORT']); ?>:5173/@vite/client"></script>
-    <script type="module" src="<?php echo preg_replace('/:\d+$/', '', $_SERVER['DDEV_PRIMARY_URL_WITHOUT_PORT']); ?>:5173/src/main.js"></script>
+    <script type="module" src="<?php echo getenv('DDEV_PRIMARY_URL_WITHOUT_PORT'); ?>:5173/@vite/client"></script>
+    <script type="module" src="<?php echo getenv('DDEV_PRIMARY_URL_WITHOUT_PORT'); ?>:5173/src/main.js"></script>
     <!-- see https://vitejs.dev/guide/backend-integration.html -->
 
 </head>


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/giscus-comments/discussions/23#discussioncomment-17718878

> Thanks for the guide/intro.
> 
> I had some problems with the current version (here) from the guide.
> 
> When loading the page the CSS would not load and I found the reason in the HTML head tag: Undefined array key.
> 
> `<script type="module" src="&lt;br /&gt; &lt;b&gt;Warning&lt;/b&gt;: Undefined array key " ddev_primary_url_without_port"="" in="" <b="">/var/www/html/web/index.php</b> on line <b>10</b><br /> <br /> <b>Deprecated</b>: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in <b>/var/www/html/web/index.php</b> on line <b>10</b><br /> :5173/@vite/client"></script>`
> 
> After some research I found out that the GitHub repo had some changes and I applied/replaced the `index.php` code from below
> 
> [mandrasch/ddev-vite-simple-demo@9e56a88](https://github.com/mandrasch/ddev-vite-simple-demo/commit/9e56a881264d681ca59b3d996468d22d652d4b85)
> 
> and now the CSS gets loaded.
> 
> Maybe this helps somebody.

## How This PR Solves the Issue

1. We don't need to use `preg_replace()` here - the variable is already in the correct format.
2. Using `$_SERVER` is not obvious - it's clearer to use `getenv()`.
3. Clarify that `DDEV_PRIMARY_URL_WITHOUT_PORT` requires a newer version of DDEV.

## Manual Testing Instructions

https://pr-679.ddev-com-fork-previews.pages.dev/blog/working-with-vite-in-ddev/

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
