### PR TITLE
content: refresh maintainer funding and sustainability posts, for #661

### DIFF
--- a/src/content/blog/expanding-ddev-maintainer-team.md
+++ b/src/content/blog/expanding-ddev-maintainer-team.md
@@ -1,14 +1,19 @@
 ---
 title: "Expanding the DDEV maintainer team - how we'll fund it"
 pubDate: 2023-09-28
-modifiedDate: 2024-07-31
-summary: Why is DDEV adding a new full-time maintainer, and how do the finances work?
+modifiedDate: 2026-07-25
+modifiedComment: "Removed the 2023 funding figures and maintainership roster, which are long out of date, and pointed to the sponsor page and current funding post instead"
+summary: What do DDEV maintainers actually do, and why does the project need more than one paid full-time?
 author: Randy Fay
 featureImage:
   src: /img/blog/2023/08/contributors-working.png
   alt: Contributors working together on DDEV
 categories:
   - Community
+---
+
+**Update (2026-07-25)**: The case for paid maintainers below still holds, and DDEV now has two working full-time. The specific 2023 dollar figures and maintainer roster that used to appear here were badly out of date, so they've been removed — see the [sponsor page](/sponsor) for the live funding total and [Let's Fully Fund Maintainer Stas](lets-fund-stas-maintainer.md) for where things stand today.
+
 ---
 
 ## Why does DDEV want to hire another full-time maintainer?
@@ -39,25 +44,15 @@ But first, what do maintainers do? Why are they so busy? Why is it important to 
 
 **The community and its needs are growing**: More CMSs have adopted DDEV as their go-to local development environment (Silverstripe this year, Craft CMS last year, etc.). That means we have new and different users with new and different needs. What fun! So great! But this will eventually strain our current abilities to support.
 
-### What is DDEV’s Current Funding Situation and What are the Goals?
+### What is DDEV’s Funding Situation and What are the Goals?
 
-**Current Funding**:
-
-- **[Platform.sh](http://Platform.sh)** pays Randy’s salary and provides benefits to him as an employee. That is an amazing benefit for this community and goes a long way! THANK YOU!
-- **Major sponsors [Tag1](https://tag1.com/), and [i-gelb](https://i-gelb.net/)** together account for USD$1500/month in funding. THANK YOU!
-- **Many other agencies and individuals** via GitHub Sponsors account for about USD$1500. THANK YOU!
-
-**Funding Goal**: Our goal is salary for a full-time paid maintainer, estimated at about USD$7,000/month or USD$84,000/year. Thanks you we’re already about 50% of the way there!
-
-### What is the Current Maintainership Situation?
-
-Currently **[Randy Fay](https://github.com/rfay), [Simon Gilli](https://github.com/gilbertsoft) and [Stas Zhuk](https://github.com/stasadev)** have maintainer privileges. Simon has made enormous contributions over the years and knows how to handle most maintainer roles. He has been periodically paid by the DDEV Foundation for his work, but his available time is sometimes spotty. Stas is new to the role after many, many important contributions and thanks to your contributions he is already being paid for part-time work.
+The goal is enough recurring sponsorship to pay maintainers for the work described above, rather than fitting it around client work. Because the numbers move every month, they live on the [sponsor page](/sponsor), which shows the current recurring total against the Foundation’s goal. For the story of how the funding has evolved — including [Platform.sh becoming lead sponsor](platform-sh-becomes-a-lead-sponsor-of-ddev.md), the [2025 change in that arrangement](platform-sh-ddev-funding-changes.md), and the [ongoing push to fully fund maintainer Stas Zhuk](lets-fund-stas-maintainer.md) — follow those posts.
 
 ### What is the DDEV Foundation?
 
 **The [DDEV Foundation](/foundation)** is the “fiscal entity” that is used for DDEV funding and is used to pay contributors. It is a certified [US 501(c)(3) nonprofit](501c3.md). The DDEV Foundation owns the bank account.
 
-No funding to the DDEV Foundation goes to Randy.
+(When this was written in 2023, no Foundation funding went to Randy, since Platform.sh employed him directly. That [changed in 2025](platform-sh-ddev-funding-changes.md), and the Foundation now budgets for both maintainers.)
 
 ### How can Your Agency, Hosting Company, or you as an Individual Help?
 

--- a/src/content/blog/introducing-maintainer-stas.md
+++ b/src/content/blog/introducing-maintainer-stas.md
@@ -1,6 +1,8 @@
 ---
 title: "Introducing New DDEV Maintainer Stas Zhuk"
 pubDate: 2023-10-24
+modifiedDate: 2026-07-25
+modifiedComment: "Added a note that Stas has worked on DDEV full-time since 2024"
 summary: Introducing New Maintainer Stas Zhuk
 author: Randy Fay
 featureImage:
@@ -10,9 +12,13 @@ categories:
   - Community
 ---
 
+**Update (2026-07-25)**: Stas has worked on DDEV full-time since 2024. See [Let's Fully Fund Maintainer Stas](lets-fund-stas-maintainer.md) for where funding for that role stands now. The introduction below is from October 2023.
+
+---
+
 I'm so happy to introduce new DDEV maintainer [Stas Zhuk](https://github.com/stasadev). He now has all privileges on the project and is beginning the onboarding to know how to use all those privileges, including maintaining tests, test runners, code, contributions, and everything else. He joins [Simon Gilli](https://github.com/gilbertsoft) and me as maintainer.
 
-It's your support that has made it possible for the DDEV Foundation to pay Stas on a part-time basis, so THANK YOU for supporting DDEV! This is a part of our path to a [long-term sustainable project](/blog/expanding-ddev-maintainer-team).
+It's your support that has made it possible for the DDEV Foundation to pay Stas on a part-time basis, so THANK YOU for supporting DDEV! This is a part of our path to a [long-term sustainable project](expanding-ddev-maintainer-team.md).
 
 Stas's arrival is very timely, as my wife Nancy Lewis and I will be traveling in Patagonia for 2 months in December and January, and I'll have very limited internet access. I'm so happy to have Stas on board to help with project support and maintenance!
 

--- a/src/content/blog/lets-fund-stas-maintainer.md
+++ b/src/content/blog/lets-fund-stas-maintainer.md
@@ -1,7 +1,8 @@
 ---
 title: "Let's Fully Fund Maintainer Stas"
 pubDate: 2024-08-01
-# modifiedDate: 2024-08-01
+modifiedDate: 2026-07-25
+modifiedComment: "Updated for 2026: Stas has been full-time on DDEV since 2024, but the role is only about 80% funded and sponsorship is at 83% of the $12,000/month goal; refreshed the Upsun funding history, Stas' contribution numbers, and the maintenance examples"
 summary: "Let's fully fund DDEV maintainer Stas Zhuk"
 author: Randy Fay
 featureImage:
@@ -11,28 +12,33 @@ categories:
   - Announcements
 ---
 
-We all want DDEV to be fully maintained at the level you depend on. Now is the time to fully fund maintainer Stas Zhuk so that he does not have to take on other client work.
+**Update (2026-07-25)**: You did it — mostly. Stas left client work behind and has been working on DDEV full-time since 2024, which is exactly what this post asked for. What hasn't caught up is the funding: his full-time maintainer role is only about 80% funded. Recurring sponsorship is about $9,900/month, or 83% of the DDEV Foundation's $12,000/month goal for both maintainers, leaving a gap of roughly $2,000/month. So the title still applies, just for a different reason: DDEV already depends on a full-time maintainer that the community isn't yet fully paying for. The numbers and examples below have been updated for 2026; the [sponsor page](/sponsor) always shows the current live total.
 
-**DDEV's Funding**: DDEV is funded in a variety of ways. [Platform.sh covers Randy's salary](platform-sh-becomes-a-lead-sponsor-of-ddev.md), thanks! Individuals and organization sponsors fund DDEV via [sponsorship](/sponsor) and invoiced support commitments. As the pace of required maintenance and features has increased, we've explained how we intend to grow our maintainership for the long-term in a [couple](recruiting-maintainers.md) of [blog posts](expanding-ddev-maintainer-team.md). (DDEV's "fiscal entity" for funding is the US 501(c)(3) [DDEV Foundation](/foundation)).
+---
 
-**Stas' Role as DDEV Maintainer**: In October, 2023, we [introduced Stas to the community](introducing-maintainer-stas.md) as our second maintainer. Since then, he has done amazing things, working as a part-time paid maintainer. He knows how all the testing and the various infrastructures work, has mastered the Go and Docker codebase, and has contributed hundreds of bugfixes, features, and documentation improvements. As of today, he has contributed [211 commits](https://github.com/ddev/ddev/graphs/contributors) to the master branch of the `ddev/ddev` project alone, second only through the whole history of DDEV to yours truly. Take a look at his [600+](https://github.com/stasadev?tab=overview&from=2024-07-01&to=2024-07-31&org=ddev) contributions to the DDEV org **just in 2024 alone**. He maintains add-ons, supports new contributors, answers questions in Discord, Slack, Stack Overflow, and the GitHub issue queue.
+We all want DDEV to be fully maintained at the level you depend on. Maintainer Stas Zhuk already does that work full-time. Now is the time to fully fund it.
+
+**DDEV's Funding**: DDEV is funded by individuals and organizations via [sponsorship](/sponsor) and invoiced support commitments. [Upsun](https://upsun.com) (formerly Platform.sh) [became lead sponsor in 2022](platform-sh-becomes-a-lead-sponsor-of-ddev.md) and remains a generous partner sponsor, though in 2025 they [changed their approach](platform-sh-ddev-funding-changes.md) from employing Randy to funding the Foundation directly, and in 2026 they [completed transfer of the DDEV trademark to the DDEV Foundation](upsun-trademark-transfer-complete.md). One consequence: the Foundation now has to budget for _both_ maintainers, which is why the funding goal covers both of us. As the pace of required maintenance and features has increased, we've explained how we intend to grow our maintainership for the long-term in a [couple](recruiting-maintainers.md) of [blog posts](expanding-ddev-maintainer-team.md), and laid out the bigger picture in [Sustainability for DDEV](sustainability-for-ddev.md). (DDEV's "fiscal entity" for funding is the US 501(c)(3) [DDEV Foundation](/foundation)).
+
+**Stas' Role as DDEV Maintainer**: In October, 2023, we [introduced Stas to the community](introducing-maintainer-stas.md) as our second maintainer, and since 2024 he has worked on DDEV full-time. He knows how all the testing and the various infrastructures work, has mastered the Go and Docker codebase, and has contributed thousands of bugfixes, features, and documentation improvements. As of July 2026, he has contributed [600 commits](https://github.com/ddev/ddev/graphs/contributors) to the main branch of the `ddev/ddev` project alone, second only through the whole history of DDEV to yours truly — nearly triple the 211 he had when this post was first written. He maintains add-ons, supports new contributors, answers questions in Discord, Slack, and the GitHub issue queue. If you want a sense of the person behind the work, read TheDropTimes' interview, [The Work Behind the Workflow](https://www.thedroptimes.com/interview/66467/work-behind-workflow-stas-zhuk-and-future-ddev). Nearly everything you rely on in a DDEV release passes through him.
 
 **Why is DDEV Maintenance Important?** You and DDEV are engulfed in a maelstrom of change. Upstream technologies change on you weekly. Things break from all directions. If DDEV weren't cared for daily, it would fail to serve you within a pretty short time.
 
-- PHP 8.4 support was added today to DDEV HEAD (along with versions 5.6-8.3!).
-- Drupal 11 is coming out this week. DDEV has already had support for some time.
-- PostgreSQL 16 and MariaDB 11.4 already have support, and MySQL 8.4 will shortly when some upstream support becomes available.
-- Recently [MariaDB changed their `mysqldump` output file format](mariadb-dump-breaking-change.md), causing a few of you to pull your hair out, until DDEV incorporated informal and then fully-integrated workarounds, so there are some of you that don't even know this happened.
+- PHP 8.5 is supported, as is every version back to 5.6, so both your newest and your oldest projects keep working.
+- Drupal 11 is the current stable release and DDEV already handles Drupal 12; explicit Joomla support arrived in v1.25.2.
+- MariaDB 12.3 LTS, PostgreSQL 18, and MySQL 8.4 are all supported.
+- The container world keeps moving underneath us. DDEV had to [require Docker Buildx](docker-buildx-requirement-v1-25-1.md) in v1.25.1, and now supports [Podman and rootless Docker](podman-and-docker-rootless.md) as well.
+- Back in 2024 [MariaDB changed their `mysqldump` output file format](mariadb-dump-breaking-change.md), causing a few of you to pull your hair out, until DDEV incorporated informal and then fully-integrated workarounds, so there are some of you that don't even know this happened.
 
-I'm just naming a tiny few of the things DDEV has had to react to in the last few months.
+I'm just naming a tiny few of the things DDEV has had to react to.
 
-**What is our current financial situation?** Currently DDEV receives donations in the range of USD$3000-$5000/month. Our expenses are in that same range, the bulk being part-time hourly support for Stas. As of today we have about $18,000 in the bank. Financial reports are provided with every meeting of the [DDEV Advisory Group](https://github.com/orgs/ddev/discussions/categories/ddev-advisory-group).
+**What is our current financial situation?** Recurring sponsorship is currently about $9,900/month against a goal of $12,000/month, which covers both maintainers. The bulk of our expenses is maintainer time. Financial reports are provided with every meeting of the [DDEV Advisory Group](https://github.com/orgs/ddev/discussions/categories/ddev-advisory-group), and since late 2025 the Foundation also has a board.
 
-**What do we want to do? Increase income by about $3000/month.** In order for Stas to be able to leave behind his client work, we need approximately $3000/month more in committed support for the next year. This could be $1,000/month from three organizations (joining fabulous supporting agency [Tag1 Consulting](https://tag1consulting.com)), $500/month from 6 organizations, joining [i-gelb](https://i-gelb.net/). Or $100/month from 30 organizations, joining [so many individual and corporate sponsors](https://ddev.com/#supporters) who keep DDEV going.
+**What do we want to do? Increase income by about $2,000/month.** That's the difference between a full-time maintainer role the Foundation can commit to for the long haul and one that is renegotiated against the budget every year. This could be $1,000/month from two organizations (joining fabulous supporting agency [Tag1 Consulting](https://tag1consulting.com)), $500/month from four organizations, joining [i-gelb](https://i-gelb.net/). Or $100/month from 20 organizations, joining [so many individual and corporate sponsors](https://ddev.com/#supporters) who keep DDEV going.
 
-**How can you or your organization support DDEV?** For agencies, hosting folks, other organizations, we're happy to bill you monthly or annually, just ask! It's easy. Some orgs prefer to use GitHub Sponsors, that's fine too. For individuals, the easiest way is to [become a sponsor](/sponsor).
+**How can you or your organization support DDEV?** For agencies, hosting folks, other organizations, we're happy to bill you monthly or annually, just ask! It's easy. For individuals, the easiest way is to [become a sponsor](/sponsor). Organizations sponsoring at $100/month or more now get [partner perks](/sponsor) as well.
 
-**Is your organization budgeting for 2025?** Please remember DDEV!
+**Is your organization budgeting for 2027?** Please remember DDEV!
 
 **Get in touch!** I'd be happy to talk to you or your organization. Send [an email](mailto:randy.fay%40ddev.com). Make an [appointment for a video call](https://cal.com/randyfay/30min).
 

--- a/src/content/blog/sustainability-for-ddev.md
+++ b/src/content/blog/sustainability-for-ddev.md
@@ -1,7 +1,8 @@
 ---
 title: "Securing DDEV’s Future: Our Commitment to Financial & Community Sustainability"
 pubDate: 2025-06-10
-#modifiedDate: 2025-06-09
+modifiedDate: 2026-07-25
+modifiedComment: "Recorded that the governance goal was met with the December 2025 Board of Directors, and replaced the June 2025 financial snapshot with pointers to the live figures"
 summary: How we’re building governance, financial, and community structures to ensure DDEV thrives beyond any single maintainer.
 author: Randy Fay
 featureImage:
@@ -40,7 +41,7 @@ Vim had serious challenges in all these areas, as there was only one "owner" of 
 
 We work hard to identify areas that are dependent on a single maintainer, and to resolve those. But it's a perpetual process!
 
-- **Governance**: From the beginning of DDEV, Randy has been the leader, acting as what's commonly called a "Benevolent Dictator for Life", or "BDFL". While that's a common model in open source, it's not a great model for overall sustainability. The BDFL model means that leadership can be concentrated in one person, preventing the development of community decision-making capabilities. One of our key goals for 2025 is to at least _start_ moving past that model.
+- **Governance**: From the beginning of DDEV, Randy has been the leader, acting as what's commonly called a "Benevolent Dictator for Life", or "BDFL". While that's a common model in open source, it's not a great model for overall sustainability. The BDFL model means that leadership can be concentrated in one person, preventing the development of community decision-making capabilities. One of our key goals for 2025 was to at least _start_ moving past that model — and we did, [establishing a Board of Directors](board-of-directors-established.md) in December 2025.
 - **Regulatory**: Randy has dealt with Colorado and US regulatory requirements, including getting the 501(c)(3) tax-exempt designation, changing the name of the organization to "DDEV Foundation", filing annual reports.
 - **Finance and Reporting**: Randy does the bimonthly financial reporting, tracks invoices, corresponds with donors, sends thank-you notes to donors, pays maintainers.
 - **Promotion/Marketing**: Randy seems to keep these roles year-in and year-out despite attempts to spread out the work
@@ -50,13 +51,13 @@ We work hard to identify areas that are dependent on a single maintainer, and to
 
 - **Improved Marketing/Monetization**: As discussed above, open-source projects generally have a hard time asking for money because people take them for granted. We do hope to move toward adding premium features and premium support options that will encourage organizations and individuals to step up to the plate and do their fair share of support.
 - **Financial**: More than one person should know how to do (and have power to do) all the financial things, like paying contributors and other bills.
-- **Governance**: Figure out how to move from BDFL to something that lasts beyond one person. A [proposal](https://github.com/orgs/ddev/discussions/7293) is in progress.
+- **Governance**: Move from BDFL to something that lasts beyond one person. The [proposal](https://github.com/orgs/ddev/discussions/7293) that was in progress when this was written became the [DDEV Foundation Board of Directors](board-of-directors-established.md) in December 2025. The next part is the harder part: the Board growing into a real oversight and priority-setting role.
 - **Write up regulatory and financial tasks**: We have a good set of documents and a private repository that explain maintainer tasks. This all needs to be done for governance, regulatory, financial, and marketing tasks.
 - **You**: DDEV is a collaborative open-source project. Are you interested in a role?
 
-## Current Financial Status
+## Financial Status
 
-As of June, 2025, DDEV's monthly support is at the $7800 USD level. Our goal is $12,000. You can see this at any time on the top of [ddev.com](/), and a full accounting updated daily is in the [sponsorship-data](https://github.com/ddev/sponsorship-data/) repository. Our current bank balance is about $19,000 USD.
+When this was written in June 2025, DDEV's monthly support was at the $7,800 USD level against a goal of $12,000. Rather than repeat a number that goes stale, we'll point you at the live figures: the current recurring total is on the [sponsor page](/sponsor) and at the top of [ddev.com](/), and a full accounting updated daily is in the [sponsorship-data](https://github.com/ddev/sponsorship-data/) repository. Financial reports are also presented at each [Advisory Group](https://github.com/orgs/ddev/discussions/categories/ddev-advisory-group) meeting.
 
 ## Share Your Thoughts!
 

--- a/src/content/blog/upsun-thank-you-new-sponsors-needed.md
+++ b/src/content/blog/upsun-thank-you-new-sponsors-needed.md
@@ -1,6 +1,8 @@
 ---
 title: "Thanks to Upsun, and Your Help is Needed Now!"
 pubDate: 2025-12-08
+modifiedDate: 2026-07-25
+modifiedComment: "Added a note that the community filled the funding gap this post warned about — sponsorship recovered from a projected 53% of goal to 83%"
 summary: A thank-you to Upsun for years of support and ongoing support, but recognition that we need new sponsors after their support level decreases again next month.
 featureImage:
   src: /img/blog/2025/12/upsun-ddev.png
@@ -8,6 +10,10 @@ featureImage:
 author: Randy Fay
 categories:
   - Community
+---
+
+**Update (2026-07-25)**: You filled the gap. This post projected sponsorship dropping to about 53% of goal in January 2026; instead it recovered to about $9,900/month, or 83% of the $12,000/month goal, and Upsun [completed the transfer of the DDEV trademark to the DDEV Foundation](upsun-trademark-transfer-complete.md). Thank you to everyone who stepped up. The work isn't finished — the remaining gap is described in [Let's Fully Fund Maintainer Stas](lets-fund-stas-maintainer.md), and the [sponsor page](/sponsor) always shows the live total. The appeal below is from December 2025.
+
 ---
 
 **TL;DR** [Upsun](https://upsun.com) has been (and remains) a great sponsor of DDEV, but is lowering their support level next month. We need you to fill the gap!
@@ -26,7 +32,7 @@ DDEV is free and open-source because sponsors like you make it possible. Whether
 
 **Ways to sponsor:**
 
-- **[GitHub Sponsors](/sponsor)** - Quick and easy, starting at any amount, personal or organizational.
+- **[Sponsorship](/sponsor)** - Quick and easy, starting at any amount, personal or organizational.
 - **Support contracts** - Get priority support while funding development
 - **Custom invoicing** - We work with your procurement process
 - **One-time contributions** - Every bit helps!

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -62,7 +62,7 @@ const activeUsers = await getActiveUsers()
             transition to the <a href="https://upsun.com">Upsun brand</a>, although at a lower level.
           </p>
           <p>
-            In 2023, <a href="/blog/introducing-maintainer-stas">Stas Zhuk</a> came aboard as an additional full-time maintainer and has made
+            In 2023, <a href="/blog/introducing-maintainer-stas">Stas Zhuk</a> came aboard as an additional maintainer, full-time since 2024, and has made
             amazing and constant contributions to the project.
           </p>
           <p>


### PR DESCRIPTION
Cleanup for #661, covering the maintainer-funding cluster of posts. Three of these are checklist items on that issue; the other three are places the same stale claims surfaced during review.

## Pages to review

Preview base: https://pr-692.ddev-com-fork-previews.pages.dev/

| Page | What changed | Compare |
| --- | --- | --- |
| [lets-fund-stas-maintainer](https://pr-692.ddev-com-fork-previews.pages.dev/blog/lets-fund-stas-maintainer/) | Reframed and updated for 2026 (issue item) | [live](https://ddev.com/blog/lets-fund-stas-maintainer/) |
| [upsun-thank-you-new-sponsors-needed](https://pr-692.ddev-com-fork-previews.pages.dev/blog/upsun-thank-you-new-sponsors-needed/) | Update note: the funding gap got filled | [live](https://ddev.com/blog/upsun-thank-you-new-sponsors-needed/) |
| [sustainability-for-ddev](https://pr-692.ddev-com-fork-previews.pages.dev/blog/sustainability-for-ddev/) | Governance goal marked delivered; financial snapshot de-staled (issue item) | [live](https://ddev.com/blog/sustainability-for-ddev/) |
| [expanding-ddev-maintainer-team](https://pr-692.ddev-com-fork-previews.pages.dev/blog/expanding-ddev-maintainer-team/) | 2023 funding figures and maintainer roster removed (issue item) | [live](https://ddev.com/blog/expanding-ddev-maintainer-team/) |
| [introducing-maintainer-stas](https://pr-692.ddev-com-fork-previews.pages.dev/blog/introducing-maintainer-stas/) | Update note that Stas has been full-time since 2024 | [live](https://ddev.com/blog/introducing-maintainer-stas/) |
| [about](https://pr-692.ddev-com-fork-previews.pages.dev/about/) | One-line correction to when Stas went full-time | [live](https://ddev.com/about/) |

## What was wrong

**The central ask in `lets-fund-stas-maintainer` had already been met.** The post asked readers to fund Stas so he could leave client work behind. He did, in 2024, and has been full-time since — but the role is only about 80% funded. The post is reframed around that: the community delivered the maintainer, the funding hasn't fully caught up. Also updated:

- "Platform.sh covers Randy's salary" — false since the [2025 funding change](https://ddev.com/blog/platform-sh-ddev-funding-changes/). Replaced with the Upsun sponsorship and trademark-transfer history.
- Sponsorship figures: ~$9,900/month, 83% of the $12,000/month goal, ~$2,000/month gap. The ask was rescaled from $3,000/month, and the sponsor multiples with it.
- Stas' commits: 211 → 600, and `master` → `main`.
- Maintenance examples refreshed from 2024 (PHP 8.4, PostgreSQL 16, MariaDB 11.4) to current, verified against `pkg/nodeps` in `ddev/ddev`: PHP 5.6–8.5, Drupal 12 support present, MariaDB 12.3 LTS, PostgreSQL 18, plus Buildx and Podman/rootless as container-churn examples.
- "Is your organization budgeting for 2025?" → 2027. Dropped the stale "$18,000 in the bank."

**`upsun-thank-you-new-sponsors-needed` was the most misleading page on the site.** This December 2025 appeal projected sponsorship dropping to about 53% of goal in January 2026. It recovered to 83% instead, so the live page was telling readers DDEV was half-funded. Added an update note recording that the community filled the gap — a good story that was going untold — and relabeled the `/sponsor` link, which still said "GitHub Sponsors" (see e49a310).

**`sustainability-for-ddev` still listed the Board of Directors as pending.** Both the "Areas to Improve" and "What Comes Next" sections described moving past the BDFL model as a goal with "a proposal in progress." That shipped in December 2025. Its "Current Financial Status" heading also presented June 2025 figures, including a bank balance, as current; that section now points at the live sources so it can't go stale again.

**`expanding-ddev-maintainer-team`** had the 2023 dollar figures, the $7,000/month goal, "about 50% of the way there," and a maintainer roster listing three people. Those sections are removed in favour of a pointer to `/sponsor` and the current funding post. The evergreen "What Do Maintainers Do?" and "Why Do We Want More Full-time Paid Maintainers?" sections are kept — five other posts cite this one for that argument, and `/sponsor` doesn't make it. Also corrected "No funding to the DDEV Foundation goes to Randy," which the 2025 change made false.

## Notes for the reviewer

- **Nothing was deleted, so no redirects are needed and no inbound links broke.** In particular the `open-source-pledge` → `lets-fund-stas-maintainer` link flagged on #661 still resolves.
- Dated archives were deliberately left alone — `2023-review`, `2025-plans`, `2025-review`, and the newsletters all contain part-time-Stas and maintainer-roster references that are correct as history.
- The Simon Gilli mention in `introducing-maintainer-stas` is untouched. It was accurate in 2023, and per `2025-plans` we've lost contact with him; a present-tense correction there would mean editorializing about that in a post that isn't about him. His entry in the `expanding-ddev-maintainer-team` roster went away with that whole section rather than being singled out.
- Stas' self-introduction in `introducing-maintainer-stas` is left in his own words, including the 2023 description of his day job. The update note at the top carries the correction instead.
- **Two things I couldn't source, both left out rather than guessed:** a current bank balance, and how Foundation finance work now divides between Randy and Treasurer Mike Anello. `sustainability-for-ddev` still assigns financial reporting, regulatory filings, and marketing to Randy alone.
- The `summary` frontmatter on `expanding-ddev-maintainer-team` changed, since "how do the finances work?" no longer describes it. That's visible in blog listings and RSS.

Verified with `ddev prettier`, `ddev textlint`, and a full `ddev npm run build` (216 pages); every relative markdown link was confirmed to resolve in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
