### PR TITLE
content: update Guy Sartorelli to Chloe Sartorelli, ignore rueegger.me in linkspector

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -30,6 +30,8 @@ ignorePatterns:
   - pattern: "^https://(www\\.)?reddit\\.com"
   # Rejects linkspector's HTTP/2 requests from CI runners.
   - pattern: "^https://firesphere\\.dev/articles/ddev-elasticsearch-and-silverstripe$"
+  # Blocks or is unreachable from CI runners, even though the site is up.
+  - pattern: "^https://(www\\.)?rueegger\\.me"
 aliveStatusCodes:
   - 200
   - 206

--- a/src/content/blog/2025-plans.md
+++ b/src/content/blog/2025-plans.md
@@ -88,7 +88,7 @@ This section is updated for our annual review of the past year at the [DDEV Advi
 
 - Stas Zhuk as a maintainer has been a massive success in so many ways. Not only is he completely technically fluent with DDEV in every area, but he loves supporting DDEV users, and we've been progressively successful in making sure he has adequate control of most areas of external accounts, etc.
 - Despite our challenges, our finances are currently in balance, and our expenditures are within our means. This is a result of many wonderful sponsors, both individuals and organizations. Thank you!
-- Outstanding contributors like tyler36, GuySartorelli, Hanoii, Bernardo Martinez, and Ralf Koller and many others continued to improve the project.
+- Outstanding contributors like tyler36, ChloeSartorelli, Hanoii, Bernardo Martinez, and Ralf Koller and many others continued to improve the project.
 - We continue to offer world-class support to DDEV users in many venues. In most cases, our community's response is better than any commercial organization can offer. I think this has to do with the quality of the software (most people don't need support) and also with our community's overall commitment to generous and friendly support.
 - We worked hard at [Live Contributor Training](/blog/category/training/), and recorded blogs and training sessions, which is great. It's not clear how successful these were in enabling new contributors, but occasional reports say that the recorded sessions have been helpful.
 - Prompted largely by The Drop Times we created the automatically-updated [sponsorship-data](https://github.com/ddev/sponsorship-data) repository, which has lots of potential for communicating about DDEV's funding status.

--- a/src/content/blog/release-v1.23.5-auto-port-assignment.md
+++ b/src/content/blog/release-v1.23.5-auto-port-assignment.md
@@ -17,7 +17,7 @@ I'm happy to announce that [DDEV v1.23.5](https://github.com/ddev/ddev/releases/
 
 **Automatic Time Zones**: It's been possible to specify the time zone for the web container for years, but automating it was suggested by community member [Martin Anderson-Clutz (mandclu)](https://www.drupal.org/u/mandclu) in the Drupal Slack and implemented by Stas. We think that it will "just work" for almost everybody.
 
-**`ddev get` becomes `ddev add-on`**: Community member [Guy Sartorelli](https://github.com/GuySartorelli) took this one on and nailed it. He noticed that `ddev get` had outgrown its name and now had too many weird permutations, so now we have `ddev add-on list` and `ddev add-on remove` and things that make more sense. Don't worry, the same capabilities are still there, and `ddev get` still works the way it did, it just nags you a little bit when you use the old command.
+**`ddev get` becomes `ddev add-on`**: Community member [Chloe Sartorelli](https://github.com/ChloeSartorelli) took this one on and nailed it. They noticed that `ddev get` had outgrown its name and now had too many weird permutations, so now we have `ddev add-on list` and `ddev add-on remove` and things that make more sense. Don't worry, the same capabilities are still there, and `ddev get` still works the way it did, it just nags you a little bit when you use the old command.
 
 **Windows ARM64 Support**: Those fancy new Windows ARM64 laptops are being promoted for their AI, but they're fantastic machines for performance and battery life. DDEV has full support for them, both on WSL2 and traditional Windows.
 


### PR DESCRIPTION
## Summary
- Contributor GuySartorelli is now ChloeSartorelli on GitHub; updates the name, GitHub link, and pronoun reference in two blog posts.
- Adds `rueegger.me` to `.linkspector.yml` ignore patterns since it's unreachable from CI runners despite being up.

## Test plan
- [ ] Re-run the "Check blog links" CI job and confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)