### PR TITLE
style: make ddev-auto.svg preview follow the theme toggle on /brand

### DIFF
--- a/src/pages/brand.mdx
+++ b/src/pages/brand.mdx
@@ -37,7 +37,7 @@ Quick reference for using the DDEV name and logo. For the full brand guide, addi
     <img
       src="/logos/ddev-auto.svg"
       alt="DDEV word mark that follows the system color scheme"
-      class={logo}
+      class={`${logo} scheme-light dark:scheme-dark`}
       width="293"
       height="69"
     />


### PR DESCRIPTION
## The Issue

Theme toggle doesn't work with `ddev-auto.svg` (the "DDEV" text has the wrong color):

<img width="615" height="876" alt="before" src="https://github.com/user-attachments/assets/bec66483-c125-40e1-b6a8-ac4104d85e03" />

## How This PR Solves The Issue

Fixes it:

<img width="615" height="876" alt="after" src="https://github.com/user-attachments/assets/f5e42d3f-2e0e-4dc7-b0fb-98e83b8f5478" />

## Manual Testing Instructions

Click the theme switch here https://pr-703.ddev-com-fork-previews.pages.dev/brand/ and look at the logos:

<img width="164" height="90" alt="image" src="https://github.com/user-attachments/assets/41c7a970-7c1d-474d-8189-7fc7f46bd748" />

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
