### PR TITLE
docs: add a pull request template, require it as the commit body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+  PR titles have very precise rules, please read
+  https://docs.ddev.com/en/stable/developers/building-contributing/#pull-request-title-guidelines
+-->
+
+## The Issue
+
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
+## Manual Testing Instructions
+
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,15 @@ Before committing changes, always run:
 When making commits after major changes, use AI-assisted commit messages that include:
 
 - Clear description of changes made
+- A body following `.github/PULL_REQUEST_TEMPLATE.md`, HTML comments removed and empty sections dropped, so it can be reused as the pull request description
+- A short body: a few lines per section, no restating the diff, no padding
 - End with: `🤖 Developed with assistance from [Claude Code](https://claude.ai/code)`
-- Include: `Co-Authored-By: Claude <noreply@anthropic.com>`
+- A trailer naming the model, such as `Co-authored-by: Claude Opus 5 <noreply@anthropic.com>`, model name only
+
+Manual Testing Instructions link the pull request's Cloudflare preview, not a local dev server. Ask where the branch will be pushed, since the URL differs, and use a `REPLACE_ME`-style placeholder for anything not known yet:
+
+- `ddev/ddev.com`: `https://<branch-with-dashes>.ddev-com-front-end.pages.dev/`, cut to 28 characters
+- A fork: `https://pr-<number>.ddev-com-fork-previews.pages.dev/`
 
 Only commit when explicitly requested by the user.
 


### PR DESCRIPTION
## The Issue

The repo has no pull request template, and commit bodies have no agreed shape. The `Co-authored-by` trailer has drifted too: 48 commits credit a generic `Claude` and 2 credit `Claude Sonnet 4.5`, so history doesn't record which
model wrote what.

## How This PR Solves The Issue

- Adds `.github/PULL_REQUEST_TEMPLATE.md`.
- `AGENTS.md` asks for a commit body following the template's sections, kept short, and a trailer naming the model that made the changes.
- `AGENTS.md` also records the two Cloudflare preview URL forms, upstream and fork, so Manual Testing Instructions link to the preview instead of a local dev server.

## Manual Testing Instructions

Open a pull request and confirm the description is prefilled from the template. Nothing here changes the built site, so there's nothing to check on the preview.

## Release/Deployment Notes

None.

🤖 Developed with assistance from [Claude Code](https://claude.ai/code)