### PR TITLE
fix: point Linux install snippet at packages.ddev.com with gpg verification

### DIFF
--- a/src/components/quickstart/Linux.astro
+++ b/src/components/quickstart/Linux.astro
@@ -58,10 +58,10 @@ const { latestVersion } = Astro.props
           code={`$ sudo true
 $ sudo apt-get update && sudo apt-get install -y curl
 $ sudo install -m 0755 -d /etc/apt/keyrings
-$ curl -fsSL https://pkg.ddev.com/apt/gpg.key | sudo tee /etc/apt/keyrings/ddev.asc > /dev/null
+$ curl -fsSL https://packages.ddev.com/public/gpg.key | sudo tee /etc/apt/keyrings/ddev.asc > /dev/null
 $ sudo chmod a+r /etc/apt/keyrings/ddev.asc
 $ sudo rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list
-$ printf "Types: deb\\nURIs: https://pkg.ddev.com/apt/\\nSuites: *\\nComponents: *\\nSigned-By: /etc/apt/keyrings/ddev.asc\\n" | sudo tee /etc/apt/sources.list.d/ddev.sources >/dev/null
+$ printf "Types: deb\\nURIs: https://packages.ddev.com/public/deb/ubuntu\\nSuites: resolute\\nComponents: main\\nSigned-By: /etc/apt/keyrings/ddev.asc\\n" | sudo tee /etc/apt/sources.list.d/ddev.sources >/dev/null
 $ sudo apt-get update && sudo apt-get install -y ddev
 `}
         />
@@ -72,8 +72,8 @@ $ sudo apt-get update && sudo apt-get install -y ddev
         <Terminal
           type="ubuntu"
           code={`$ sudo true
-$ printf "[ddev]\\nname=ddev\\nbaseurl=https://pkg.ddev.com/yum/\\ngpgcheck=0\\nenabled=1\\n" | sudo tee /etc/yum.repos.d/ddev.repo >/dev/null
-$ sudo dnf install --refresh ddev
+$ printf "[ddev]\\nname=ddev\\nbaseurl=https://packages.ddev.com/public/rpm/any-distro/any-version/\\$basearch\\ngpgkey=https://packages.ddev.com/public/gpg.key\\ngpgcheck=1\\nrepo_gpgcheck=1\\nenabled=1\\n" | sudo tee /etc/yum.repos.d/ddev.repo >/dev/null
+$ sudo dnf install -y --refresh ddev
 `}
         />
       </div>

--- a/src/components/quickstart/Linux.astro
+++ b/src/components/quickstart/Linux.astro
@@ -61,7 +61,7 @@ $ sudo install -m 0755 -d /etc/apt/keyrings
 $ curl -fsSL https://packages.ddev.com/public/gpg.key | sudo tee /etc/apt/keyrings/ddev.asc > /dev/null
 $ sudo chmod a+r /etc/apt/keyrings/ddev.asc
 $ sudo rm -f /etc/apt/keyrings/ddev.gpg /etc/apt/sources.list.d/ddev.list
-$ printf "Types: deb\\nURIs: https://packages.ddev.com/public/deb/ubuntu\\nSuites: resolute\\nComponents: main\\nSigned-By: /etc/apt/keyrings/ddev.asc\\n" | sudo tee /etc/apt/sources.list.d/ddev.sources >/dev/null
+$ printf "Types: deb\\nURIs: https://packages.ddev.com/public/deb/ubuntu\\nSuites: stable\\nComponents: main\\nSigned-By: /etc/apt/keyrings/ddev.asc\\n" | sudo tee /etc/apt/sources.list.d/ddev.sources >/dev/null
 $ sudo apt-get update && sudo apt-get install -y ddev
 `}
         />


### PR DESCRIPTION
## Short Summary (TL;DR)

Points the get-started page's Linux install snippet at the live `packages.ddev.com` Cloudsmith domain instead of the old Gemfury `pkg.ddev.com` URLs, and turns on yum GPG verification.

## The Issue

Companion to [ddev/ddev#8698](https://github.com/ddev/ddev/pull/8698), which moves apt/yum package hosting to Cloudsmith. This site's Linux quickstart still referenced the old Gemfury URLs and had `gpgcheck=0`.

Although this is already live and everything in it should work, we may not want to pull it until v1.25.4 comes out. We can think about that.

## How This PR Solves The Issue

Updates `src/components/quickstart/Linux.astro` apt and yum snippets to `packages.ddev.com/public/...`, matching `ddev-installation.md` in `ddev/ddev`, and enables `gpgcheck=1`/`repo_gpgcheck=1` for yum.

## Manual Testing Instructions

Rendered at https://pr-721.ddev-com-fork-previews.pages.dev/get-started/

Load that page, select Linux, and use the Debian/Ubuntu and Fedora/CentOS snippets with `packages.ddev.com` to install DDEV.

