### PR TITLE
ci: fix scheduled link-check sweep crashing on ubuntu-24.04 sandbox restriction

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -61,6 +61,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      # ubuntu-24.04 runners restrict unprivileged user namespaces via AppArmor,
+      # which Chromium's sandbox needs to launch. action-linkspector (used in the
+      # pr job above) works around this itself; a bare `npx linkspector` here
+      # does not, so it crashes with "No usable sandbox!" on every scheduled run.
+      # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      - name: Allow Chromium's user-namespace sandbox
+        run: |
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          fi
+
       - name: Run linkspector
         id: check
         run: |


### PR DESCRIPTION
## Summary
The scheduled/manual "Sweep all blog links" job runs linkspector directly via `npx`, unlike the PR job, which goes through `umbrelladocs/action-linkspector`. `ubuntu-24.04` runners restrict unprivileged user namespaces via AppArmor, which Chromium's sandbox needs to launch; `action-linkspector` already works around this internally, but the bare `npx` invocation did not, so every scheduled sweep run crashed with "No usable sandbox!" instead of producing a report. Every `pull_request` run of this workflow passed while every `schedule` run failed with the identical crash, which pointed at the difference between the two jobs.

- Add a step to the sweep job that disables the AppArmor user-namespace restriction before running linkspector, mirroring the workaround `action-linkspector` applies for the PR job.

## Test plan
- [x] Triggered the workflow manually (workflow_dispatch): https://github.com/ddev/ddev.com/actions/runs/32762961092 — the sweep job completed and produced a report instead of crashing.

🤖 Developed with assistance from [Claude Code](https://claude.ai/code)
