### PR TITLE
fix: exclude drupal.slack.com from link check, remove dead kitemetric link, fixes #727

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -48,6 +48,10 @@ ignorePatterns:
   # 2026-07-31 runs, passed on 2026-08-03. Used only for image-credit
   # attribution links.
   - pattern: "^https://(www\\.)?pixabay\\.com"
+  # Slack workspace deep links require being signed into that workspace, so
+  # linkspector's headless browser always gets a 403 even though the page is
+  # fine for a logged-in member.
+  - pattern: "^https://drupal\\.slack\\.com"
 aliveStatusCodes:
   - 200
   - 206

--- a/src/content/blog/ddev-october-2025-newsletter.md
+++ b/src/content/blog/ddev-october-2025-newsletter.md
@@ -26,7 +26,6 @@ Have ideas for DDEV in 2026? [Contact us↗](/contact).
 - **Metadrop Releases Aljibe**: Quality and testing toolkit for Drupal development with DDEV [Read more↗](https://metadrop.net/en/articles/aljibe-quality-and-testing-drupal-developments-ddev) • [The Drop Times coverage↗](https://www.thedroptimes.com/54668/metadrop-releases-aljibe-qa-and-testing-toolkit-drupal-development-with-ddev)
 - **WordPress Development with `ddev pull`**: Guide to using `ddev pull` for WordPress projects [Read more↗](https://www.koehnlein.dev/en/blog/2025/wordpress-ddev-pull/)
 - **WebHaven Now Powered by DDEV**: Development workflow success story [Read more↗](https://webhaven.io/blog/webhaven-now-powered-ddev-local-development)
-- **DDEV and PHPStorm's Node.js Remote Interpreter**: Workflow guide for ESLint, Prettier, and more [Read more↗](https://kitemetric.com/blogs/ddev-and-phpstorm-s-nodejs-remote-interpreter-a-smooth-workflow-for-eslint-prettier-and-more)
 
 ## Community Video Tutorials
 


### PR DESCRIPTION
## Description

Fixes two broken-link findings from the weekly link-check sweep (#727). The drupal.slack.com app_redirect links 403 linkspector's headless browser because they require being signed into that Slack workspace, even though the links work fine for a logged-in member, so they're excluded the same way other bot-blocking sites already are in .linkspector.yml. The kitemetric.com blog post linked from the October 2025 newsletter genuinely 404s (the site itself is up), so that roundup entry is removed.
