### PR TITLE
docs: replace tmate with upterm

### DIFF
--- a/src/content/blog/maintaining-ddev-tests-contributor-training.md
+++ b/src/content/blog/maintaining-ddev-tests-contributor-training.md
@@ -49,7 +49,7 @@ Flaky tests are the worst, because they may depend on the execution environment,
 - Review the test output from Buildkite or GitHub workflow to try to understand what's actually going on. There may be an earlier error that's reported that causes the actual failure.
 - Try to run it manually, perhaps step-debugging and introducing slower execution.
 - Try to run it on GitHub Codespaces, which is a more similar environment.
-- Try to run it using [tmate](https://github.com/mxschmitt/action-tmate) on the GitHub workflow, which is as close as you can get to the real test environment. (Tmate is built into each of the DDEV test workflows.)
+- Try to run it using [upterm](https://github.com/owenthereal/action-upterm) on the GitHub workflow, which is as close as you can get to the real test environment. (Upterm is built into each of the DDEV test workflows.)
 
 ### Fragile or brittle tests
 

--- a/src/content/blog/tmate-github-actions-contributor-training.md
+++ b/src/content/blog/tmate-github-actions-contributor-training.md
@@ -1,7 +1,8 @@
 ---
 title: "Contributor Training: Tmate for Debugging GitHub Actions Workflows"
 pubDate: 2024-10-23
-modifiedDate: 2025-02-26
+modifiedDate: 2026-09-01
+modifiedComment: "The tmate servers have been shut down, so the tmate action no longer works. DDEV workflows now use owenthereal/action-upterm instead, which works the same way: check the debug box when you dispatch a workflow, then SSH into the runner. Everything below still describes the approach, just with a different action."
 summary: Contributor training - Using tmate to debug and experiment with GitHub Actions.
 author: Randy Fay
 featureImage:


### PR DESCRIPTION
## Short Summary (TL;DR)

The tmate servers have been shut down, so two posts point contributors at a tool that no longer works. Update the live advice and flag the tmate training post.

## The Issue

- https://github.com/tmate-io/tmate/issues/322

Same change as ddev/ddev#8789.

## How This PR Solves The Issue

`maintaining-ddev-tests-contributor-training.md` gives current advice for debugging flaky tests, so its tmate link becomes an upterm link.

`tmate-github-actions-contributor-training.md` is a dated training post built around a video about tmate, so rewriting it would misrepresent what the video shows. It gets a `modifiedComment` saying tmate is gone and DDEV now uses upterm.

## Manual Testing Instructions

Build the site and check the tmate post shows the update note above the body.

## Automated Testing Overview

None.

## Release/Deployment Notes

Content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)