### PR TITLE
docs: make legacy MySQL 5.5 example restart-safe, fixes #737

### DIFF
--- a/src/content/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev.md
+++ b/src/content/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev.md
@@ -69,6 +69,7 @@ services:
         cp /docker-entrypoint.sh ~/docker-entrypoint.sh
         sed -i '157s|.*|if false; then|' ~/docker-entrypoint.sh
         sed -i '175s|.*|echo mysql_8.0 >/var/lib/mysql/db_mariadb_version.txt|' ~/docker-entrypoint.sh
+        sed -i '81i\  chmod -f -R u+w /etc/mysql/conf.d/* 2>/dev/null || true' ~/docker-entrypoint.sh
         exec ~/docker-entrypoint.sh
 ```
 
@@ -77,6 +78,7 @@ Three things are noteworthy:
 - Setting `linux/amd64` as the platform will require Rosetta to be available on the macOS ARM64 platform
 - The `BASE_IMAGE` is set to a DDEV `db` container of legacy Docker images that are still provided.
 - Changing the `entrypoint` is a workaround to prevent DDEV complaining about a mismatching MySQL version after restarting the project. The small script "tricks" the DDEV inspection into believing, the version matches the one configured in `.ddev/config.yaml`.
+- The `mysql-5.5:v1.24.6` image removes write permission from copied custom `.cnf` files, which can cause `Permission denied` when restarting an existing DB container; the added `chmod` makes this example restart-safe. This underlying issue was fixed in DDEV v1.24.7.
 
 ## Step 3: Rewire PHP
 


### PR DESCRIPTION
## The Issue

- Fixes #737

The legacy MySQL 5.5 guide pins `ddev/ddev-dbserver-mysql-5.5:v1.24.6`. With a custom `.ddev/mysql/*.cnf` file, a later start of the same DB container can fail because the old entrypoint tries to overwrite a config file after removing its write permission.

## How This PR Solves The Issue

The example now restores owner write permission on `/etc/mysql/conf.d/*` before the legacy entrypoint copies custom `.cnf` files. The added command is tolerant of an empty config directory, so the first start and later restarts both work. The article also notes that the underlying issue was fixed in DDEV v1.24.7.

## Manual Testing Instructions

https://pr-738.ddev-com-fork-previews.pages.dev/blog/legacy-projects-with-unsupported-php-and-mysql-using-ddev/

Reproduced with DDEV v1.25.4, `ddev/ddev-dbserver-mysql-5.5:v1.24.6`, MySQL 5.5.62, and a custom `.ddev/mysql/legacy.cnf`. Before the change, restarting the existing DB container failed with `cp: cannot create regular file '/etc/mysql/conf.d/legacy.cnf': Permission denied`. After the change, a direct DB-container restart completed successfully and Docker reported `running healthy`.

## Automated Testing Overview

No automated tests were added because this is a documentation-only change to a legacy example.

## Release/Deployment Notes

No deployment changes are required.

Prepared and tested with assistance from ChatGPT.